### PR TITLE
일정 리스트 sticky header 구현

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListAdapter.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListAdapter.kt
@@ -1,6 +1,7 @@
 package com.ivyclub.contact.ui.plan_list
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -8,7 +9,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.chip.Chip
 import com.ivyclub.contact.R
 import com.ivyclub.contact.databinding.ItemPlanListBinding
-import com.ivyclub.contact.util.DayOfWeek
+import com.ivyclub.contact.databinding.ItemPlanListHeaderBinding
+import com.ivyclub.contact.util.*
 import com.ivyclub.data.model.AppointmentData
 import java.util.*
 
@@ -25,24 +27,40 @@ class PlanListAdapter : ListAdapter<AppointmentData, PlanListAdapter.PlanViewHol
         holder.bind(getItem(position))
     }
 
+    fun isHeader(position: Int): Boolean {
+        if (position == 0) return true
+
+        val curCalendar = Calendar.getInstance()
+        curCalendar.time = getItem(position).date
+        val lastCalendar = Calendar.getInstance()
+        lastCalendar.time = getItem(position - 1).date
+
+        return curCalendar.get(Calendar.MONTH) != lastCalendar.get(Calendar.MONTH)
+    }
+
+    fun getHeaderView(rv: RecyclerView, position: Int): View? {
+        val item = getItem(position)
+        val date = item.date
+
+        val binding = ItemPlanListHeaderBinding.inflate(LayoutInflater.from(rv.context), rv, false)
+        binding.tvPlanMonth.text = "${date.getExactMonth()}월"
+        binding.tvPlanYear.text = "${date.getExactYear()}"
+        return binding.root
+    }
+
     inner class PlanViewHolder(
         private val binding: ItemPlanListBinding
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(data: AppointmentData) {
             val context = itemView.context
+
             with(binding) {
+                val date = data.date
 
-                val calendar = Calendar.getInstance()
-                calendar.time = data.date
-                val dayOfMonth = calendar.get(Calendar.DATE)
-                val dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK)
-                val year = calendar.get(Calendar.YEAR)
-                val month = calendar.get(Calendar.MONTH) + 1
-
-                tvPlanMonth.text = "${month}월"
-                tvPlanYear.text = year.toString()
-                tvPlanDate.text = "${dayOfMonth}일 ${DayOfWeek.values()[dayOfWeek - 1].korean}"
+                tvPlanMonth.text = "${date.getExactMonth()}월"
+                tvPlanYear.text = date.getExactYear().toString()
+                tvPlanDate.text = "${date.getDayOfMonth()}일 ${date.getDayOfWeek().korean}}"
 
                 tvPlanTitle.text = data.title
 
@@ -58,6 +76,8 @@ class PlanListAdapter : ListAdapter<AppointmentData, PlanListAdapter.PlanViewHol
                         cgPlanFriends.addView(it)
                     }
                 }
+
+                llMonthYear.visibility = if (isHeader(adapterPosition)) View.VISIBLE else View.INVISIBLE
             }
         }
     }

--- a/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListHeaderItemDecoration.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListHeaderItemDecoration.kt
@@ -1,0 +1,101 @@
+package com.ivyclub.contact.ui.plan_list
+
+import android.graphics.Canvas
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+class PlanListHeaderItemDecoration(private val sectionCallback: SectionCallback) :
+    RecyclerView.ItemDecoration() {
+
+    // onDrawOver 함수로 RecyclerView 위에 새로운 뷰를 그려준다.
+    override fun onDrawOver(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
+        super.onDrawOver(c, parent, state)
+        Log.d("DRAW", "onDrawOver 호출")
+        val topChild = parent.getChildAt(0) ?: return
+
+        val topChildPosition  = parent.getChildAdapterPosition(topChild)
+        if (topChildPosition == RecyclerView.NO_POSITION) return
+
+        /* 헤더 */
+        val currentHeader: View = sectionCallback.getHeaderLayoutView(parent, topChildPosition) ?: return
+
+        /* View의 레이아웃 설정 */
+        fixLayoutSize(parent, currentHeader, topChild.measuredHeight)
+
+        val contactPoint = currentHeader.bottom // 현재 헤더가 부모로부터 밑에서 얼만큼 떨어져 있는지
+        val childInContact: View = getChildInContact(parent, contactPoint) ?: return
+
+        val childAdapterPosition = parent.getChildAdapterPosition(childInContact)
+        if (childAdapterPosition == RecyclerView.NO_POSITION) return
+
+        when {
+            sectionCallback.isHeader(childAdapterPosition) -> moveHeader(c, currentHeader, childInContact)
+            else -> drawHeader(c, currentHeader)
+        }
+
+    }
+
+    private fun moveHeader(c: Canvas, currentHeader: View, childInContact: View) {
+        c.save()
+        c.translate(0f, childInContact.top - currentHeader.height.toFloat())
+        currentHeader.draw(c)
+        c.restore()
+    }
+
+    private fun drawHeader(c: Canvas, currentHeader: View) {
+        c.save()
+        c.translate(0f, 0f)
+        currentHeader.draw(c)
+        c.restore()
+    }
+
+    private fun getChildInContact(parent: RecyclerView, contactPoint: Int): View? {
+        var childInContact: View? = null
+        for (i in 0 until parent.childCount) {
+            val child = parent.getChildAt(i)
+            if (child.bottom > contactPoint) {
+                if (child.top <= contactPoint) {
+                    childInContact = child
+                    break
+                }
+            }
+        }
+        return childInContact
+    }
+
+    private fun fixLayoutSize(parent: RecyclerView, currentHeader: View, measuredHeight: Int) {
+        val widthSpec = View.MeasureSpec.makeMeasureSpec(
+            parent.width,
+            View.MeasureSpec.EXACTLY
+        )
+
+        val heightSpec = View.MeasureSpec.makeMeasureSpec(
+            parent.height,
+            View.MeasureSpec.EXACTLY
+        )
+
+        val childWidth: Int = ViewGroup.getChildMeasureSpec(
+            widthSpec,
+            parent.paddingStart + parent.paddingEnd,
+            currentHeader.layoutParams.width
+        )
+
+        val childHeight: Int = ViewGroup.getChildMeasureSpec(
+            heightSpec,
+            0,
+            measuredHeight
+        )
+
+        currentHeader.measure(childWidth, childHeight)
+        currentHeader.layout(0, 0, currentHeader.measuredWidth, currentHeader.measuredHeight)
+    }
+
+    interface SectionCallback {
+        // header가 고정되어있는지, 움직여야하는지 판단할 함수
+        fun isHeader(position: Int): Boolean
+        // 어떤 뷰를 그려줄지를 반환하는 함수
+        fun getHeaderLayoutView(list: RecyclerView, position: Int): View?
+    }
+}

--- a/app/src/main/java/com/ivyclub/contact/util/DateUtil.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/DateUtil.kt
@@ -1,0 +1,21 @@
+package com.ivyclub.contact.util
+
+import java.sql.Date
+import java.util.*
+
+fun Date.getExactYear(): Int = getCalendar(this).get(Calendar.YEAR)
+
+fun Date.getExactMonth(): Int = getCalendar(this).get(Calendar.MONTH) + 1
+
+fun Date.getDayOfMonth(): Int = getCalendar(this).get(Calendar.DAY_OF_MONTH)
+
+fun Date.getDayOfWeek(): DayOfWeek {
+    return DayOfWeek.values()[getCalendar(this).get(Calendar.DAY_OF_WEEK) - 1]
+}
+
+private fun getCalendar(date: Date): Calendar {
+    val calendar = Calendar.getInstance()
+    calendar.time = date
+
+    return calendar
+}

--- a/app/src/main/res/layout/item_plan_list.xml
+++ b/app/src/main/res/layout/item_plan_list.xml
@@ -4,8 +4,8 @@
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_marginVertical="8dp"
-    android:layout_marginHorizontal="16dp">
+    android:paddingVertical="8dp"
+    android:paddingHorizontal="16dp">
 
     <LinearLayout
         android:id="@+id/ll_month_year"

--- a/app/src/main/res/layout/item_plan_list_header.xml
+++ b/app/src/main/res/layout/item_plan_list_header.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/ll_month_year"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingStart="16dp"
+    android:paddingTop="16dp"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tv_plan_month"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="#3A4A40"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        tools:text="11월" />
+
+    <TextView
+        android:id="@+id/tv_plan_year"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textSize="12sp"
+        tools:text="2021" />
+</LinearLayout>


### PR DESCRIPTION
## Issue
- #2

## Overview (Required)
- 일정 리스트 스크롤시 월 정보 좌측에 붙어있도록 구현

## Links
- [참고](https://leveloper.tistory.com/205)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/48874574/139799208-4d9898bb-1361-4905-a155-5affc3a02e49.png" width="300" /> | <img src="https://user-images.githubusercontent.com/48874574/139823486-49042eba-4c0d-43e2-9b51-b21f612ab4c4.gif" width="300" />
