### PR TITLE
그룹 추가 기능

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
@@ -36,6 +36,7 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
     }
     private lateinit var friendListAdapter: FriendListAdapter
     private lateinit var dialog: Dialog
+    private val dialogBinding by lazy { DialogFriendBinding.inflate(LayoutInflater.from(context)) }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.viewModel = viewModel
@@ -69,8 +70,7 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
                         findNavController().navigate(R.id.action_navigation_friend_to_addFriendFragment)
                     }
                     R.id.item_new_group -> {
-                        this@FriendFragment.viewModel.getGroupData()
-                        dialog.show()
+                        showDialog()
                     }
                 }
                 false
@@ -86,7 +86,6 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
     }
 
     private fun initDialog() {
-        val dialogBinding = DialogFriendBinding.inflate(LayoutInflater.from(requireContext()))
         dialog = Dialog(requireContext())
         dialog.setContentView(dialogBinding.root)
 
@@ -118,6 +117,12 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
                 dialog.dismiss()
             }
         }
+    }
+
+    private fun showDialog() {
+        viewModel.getGroupData()
+        dialogBinding.etNewGroupName.text?.clear()
+        dialog.show()
     }
 
     private fun initFriendListAdapter() {

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
@@ -90,8 +90,15 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
         val layoutParams = dialog.window?.attributes
         layoutParams?.width = ConstraintLayout.LayoutParams.MATCH_PARENT
         layoutParams?.height = ConstraintLayout.LayoutParams.WRAP_CONTENT
-        dialogBinding.btnCancel.setOnClickListener {
-            dialog.dismiss()
+        with(dialogBinding) {
+            btnCancel.setOnClickListener {
+                dialog.dismiss()
+            }
+
+            btnAddNewGroup.setOnClickListener {
+                val groupName = etNewGroupName.text.toString()
+                viewModel.saveGroupData(groupName)
+            }
         }
     }
 

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.PopupMenu
 import androidx.activity.OnBackPressedCallback
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.ivyclub.contact.R
@@ -68,6 +69,7 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
                         findNavController().navigate(R.id.action_navigation_friend_to_addFriendFragment)
                     }
                     R.id.item_new_group -> {
+                        this@FriendFragment.viewModel.getGroupData()
                         dialog.show()
                     }
                 }
@@ -87,10 +89,25 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
         val dialogBinding = DialogFriendBinding.inflate(LayoutInflater.from(requireContext()))
         dialog = Dialog(requireContext())
         dialog.setContentView(dialogBinding.root)
+
         val layoutParams = dialog.window?.attributes
         layoutParams?.width = ConstraintLayout.LayoutParams.MATCH_PARENT
         layoutParams?.height = ConstraintLayout.LayoutParams.WRAP_CONTENT
+
         with(dialogBinding) {
+            friendViewModel = viewModel
+            lifecycleOwner = this@FriendFragment
+
+            viewModel.isAddGroupButtonActive.observe(viewLifecycleOwner) {
+                btnAddNewGroup.isClickable = it
+            }
+
+            etNewGroupName.doOnTextChanged { text, _, _, _ ->
+                if (text != null) {
+                    viewModel.checkGroupNameValid(text.toString())
+                }
+            }
+
             btnCancel.setOnClickListener {
                 dialog.dismiss()
             }
@@ -98,6 +115,7 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
             btnAddNewGroup.setOnClickListener {
                 val groupName = etNewGroupName.text.toString()
                 viewModel.saveGroupData(groupName)
+                dialog.dismiss()
             }
         }
     }

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.PopupMenu
 import androidx.activity.OnBackPressedCallback
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -35,7 +36,22 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
     }
     private lateinit var friendListAdapter: FriendListAdapter
     private lateinit var dialog: Dialog
-    private val dialogBinding by lazy { DialogFriendBinding.inflate(LayoutInflater.from(context)) }
+    private var _dialogBinding: DialogFriendBinding? = null
+    private val dialogBinding get() = _dialogBinding ?: error("dialogBinding이 초기화되지 않았습니다.")
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _dialogBinding = DialogFriendBinding.inflate(LayoutInflater.from(context))
+        with(dialogBinding) {
+            friendViewModel = viewModel
+            lifecycleOwner = viewLifecycleOwner
+        }
+        return super.onCreateView(inflater, container, savedInstanceState)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         binding.viewModel = viewModel
@@ -96,9 +112,6 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
         layoutParams?.height = ConstraintLayout.LayoutParams.WRAP_CONTENT
 
         with(dialogBinding) {
-            friendViewModel = viewModel
-            lifecycleOwner = viewLifecycleOwner
-
             btnCancel.setOnClickListener {
                 dialog.dismiss()
             }
@@ -151,6 +164,11 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
                 binding.rvFriendList.scrollToPosition(0)
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _dialogBinding = null
     }
 
     companion object {

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
@@ -95,7 +95,7 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
 
         with(dialogBinding) {
             friendViewModel = viewModel
-            lifecycleOwner = this@FriendFragment
+            lifecycleOwner = viewLifecycleOwner
 
             viewModel.isAddGroupButtonActive.observe(viewLifecycleOwner) {
                 btnAddNewGroup.isClickable = it

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
@@ -86,7 +86,10 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
 
     private fun initDialog() {
         dialog = Dialog(requireContext())
-        dialog.setContentView(dialogBinding.root)
+
+        if (dialogBinding.root.parent == null) {
+            dialog.setContentView(dialogBinding.root)
+        }
 
         val layoutParams = dialog.window?.attributes
         layoutParams?.width = ConstraintLayout.LayoutParams.MATCH_PARENT

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.widget.PopupMenu
 import androidx.activity.OnBackPressedCallback
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.ivyclub.contact.R
@@ -96,16 +95,6 @@ class FriendFragment : BaseFragment<FragmentFriendBinding>(R.layout.fragment_fri
         with(dialogBinding) {
             friendViewModel = viewModel
             lifecycleOwner = viewLifecycleOwner
-
-            viewModel.isAddGroupButtonActive.observe(viewLifecycleOwner) {
-                btnAddNewGroup.isClickable = it
-            }
-
-            etNewGroupName.doOnTextChanged { text, _, _, _ ->
-                if (text != null) {
-                    viewModel.checkGroupNameValid(text.toString())
-                }
-            }
 
             btnCancel.setOnClickListener {
                 dialog.dismiss()

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ivyclub.data.ContactRepository
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.GroupData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -49,6 +50,12 @@ class FriendViewModel @Inject constructor(
 
     fun removeText() {
         _searchEditTextInputText.value = ""
+    }
+
+    fun saveGroupData(groupName: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            repository.saveNewGroup(GroupData(groupName))
+        }
     }
 
     private fun sortNameWith(inputString: String) {

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendViewModel.kt
@@ -30,7 +30,7 @@ class FriendViewModel @Inject constructor(
     val isClearButtonVisible: LiveData<Boolean> get() = _isClearButtonVisible
     private val _searchEditTextInputText = MutableLiveData<String>()
     val searchEditTextInputText: LiveData<String> get() = _searchEditTextInputText
-    private val _groupNameValidation = MutableLiveData("")
+    private val _groupNameValidation = MutableLiveData(GroupNameValidation.WRONG_EMPTY.message)
     val groupNameValidation: LiveData<String> get() = _groupNameValidation
     private val _isAddGroupButtonActive = MutableLiveData(false)
     val isAddGroupButtonActive: LiveData<Boolean> = _isAddGroupButtonActive

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend/FriendViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ivyclub.contact.util.GroupNameValidation
 import com.ivyclub.data.ContactRepository
 import com.ivyclub.data.model.FriendData
 import com.ivyclub.data.model.GroupData
@@ -18,6 +19,7 @@ class FriendViewModel @Inject constructor(
 ) : ViewModel() {
 
     private var searchInputString = ""
+    private val groups = mutableListOf<String>()
     private lateinit var originEntireFriendList: List<FriendData>
 
     private val _isSearchViewVisible = MutableLiveData(false)
@@ -28,6 +30,10 @@ class FriendViewModel @Inject constructor(
     val isClearButtonVisible: LiveData<Boolean> get() = _isClearButtonVisible
     private val _searchEditTextInputText = MutableLiveData<String>()
     val searchEditTextInputText: LiveData<String> get() = _searchEditTextInputText
+    private val _groupNameValidation = MutableLiveData("")
+    val groupNameValidation: LiveData<String> get() = _groupNameValidation
+    private val _isAddGroupButtonActive = MutableLiveData(false)
+    val isAddGroupButtonActive: LiveData<Boolean> = _isAddGroupButtonActive
 
     fun getFriendData() {
         viewModelScope.launch(Dispatchers.IO) {
@@ -56,6 +62,31 @@ class FriendViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             repository.saveNewGroup(GroupData(groupName))
         }
+    }
+
+    fun getGroupData() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val groupNameList = repository.loadGroups().map { it.name }
+            groups.clear()
+            groups.addAll(groupNameList)
+        }
+    }
+
+    fun checkGroupNameValid(text: String) {
+        if (text.isEmpty()) {
+            _groupNameValidation.value = GroupNameValidation.WRONG_EMPTY.message
+            setAddGroupButtonActive(false)
+        } else if (text in groups) {
+            _groupNameValidation.value = GroupNameValidation.WRONG_DUPLICATE.message
+            setAddGroupButtonActive(false)
+        } else {
+            _groupNameValidation.value = GroupNameValidation.CORRECT.message
+            setAddGroupButtonActive(true)
+        }
+    }
+
+    private fun setAddGroupButtonActive(isActive: Boolean) {
+        _isAddGroupButtonActive.value = isActive
     }
 
     private fun sortNameWith(inputString: String) {

--- a/app/src/main/java/com/ivyclub/contact/util/EnumClasses.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/EnumClasses.kt
@@ -1,5 +1,15 @@
 package com.ivyclub.contact.util
 
+enum class GroupNameValidation : ValidationMessage{
+    WRONG_EMPTY { override val message = "0자 이상 입력해주세요." },
+    WRONG_DUPLICATE { override val message = "이미 존재하는 그룹 이름입니다."},
+    CORRECT { override val message = "" }
+}
+
+interface ValidationMessage {
+    val message: String
+}
+
 enum class DayOfWeek(val value: Int) : KoreanTranslatable {
     SUN(1) { override val korean = "일" },
     MON(2) { override val korean = "월" },

--- a/app/src/main/res/layout/dialog_friend.xml
+++ b/app/src/main/res/layout/dialog_friend.xml
@@ -1,72 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:paddingHorizontal="20dp"
-    android:paddingTop="20dp">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <TextView
-        android:id="@+id/tv_add_group_title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/friend_dialog_add_group"
-        android:textSize="20sp"
-        android:textColor="@color/green_300"
-        android:textStyle="bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/til_new_group_name"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        <variable
+            name="friendViewModel"
+            type="com.ivyclub.contact.ui.main.friend.FriendViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginHorizontal="20dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_add_group_title">
+        android:paddingHorizontal="20dp"
+        android:paddingTop="20dp">
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/et_new_group_name"
+        <TextView
+            android:id="@+id/tv_add_group_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/friend_dialog_add_group"
+            android:textColor="@color/green_300"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/til_new_group_name"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/friend_dialog_new_group_name_hint" />
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_add_group_title">
 
-    </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/et_new_group_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/friend_dialog_new_group_name_hint" />
 
-    <TextView
-        android:id="@+id/tv_duplicate_check"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:visibility="invisible"
-        android:textSize="8sp"
-        app:layout_constraintStart_toStartOf="@id/til_new_group_name"
-        app:layout_constraintTop_toBottomOf="@id/til_new_group_name" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-    <Button
-        android:id="@+id/btn_cancel"
-        style="?android:borderlessButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="4dp"
-        android:text="@string/friend_dialog_cancel"
-        android:textColor="@color/light_gray"
-        android:textSize="16sp"
-        app:layout_constraintEnd_toStartOf="@id/btn_add_new_group"
-        app:layout_constraintTop_toTopOf="@id/btn_add_new_group" />
+        <TextView
+            android:id="@+id/tv_duplicate_check"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:text="@{friendViewModel.groupNameValidation}"
+            android:textColor="#BA1A1A"
+            android:textSize="8sp"
+            app:layout_constraintStart_toStartOf="@id/til_new_group_name"
+            app:layout_constraintTop_toBottomOf="@id/til_new_group_name" />
 
-    <Button
-        android:id="@+id/btn_add_new_group"
-        style="?android:borderlessButtonStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:layout_marginEnd="4dp"
-        android:text="@string/friend_dialog_add"
-        android:textColor="@color/green_300"
-        android:textSize="16sp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/tv_duplicate_check" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <Button
+            android:id="@+id/btn_cancel"
+            style="?android:borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="4dp"
+            android:text="@string/friend_dialog_cancel"
+            android:textColor="@color/light_gray"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toStartOf="@id/btn_add_new_group"
+            app:layout_constraintTop_toTopOf="@id/btn_add_new_group" />
+
+        <Button
+            android:id="@+id/btn_add_new_group"
+            style="?android:borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:layout_marginEnd="4dp"
+            android:text="@string/friend_dialog_add"
+            android:textColor="@color/green_300"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_duplicate_check" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/dialog_friend.xml
+++ b/app/src/main/res/layout/dialog_friend.xml
@@ -40,6 +40,7 @@
                 android:id="@+id/et_new_group_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:onTextChanged="@{(text, start, before, count) -> friendViewModel.checkGroupNameValid(text.toString())}"
                 android:hint="@string/friend_dialog_new_group_name_hint" />
 
         </com.google.android.material.textfield.TextInputLayout>
@@ -77,6 +78,7 @@
             android:text="@string/friend_dialog_add"
             android:textColor="@color/green_300"
             android:textSize="16sp"
+            android:clickable="@{friendViewModel.isAddGroupButtonActive}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_duplicate_check" />
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/data/src/main/java/com/ivyclub/data/ContactRepository.kt
+++ b/data/src/main/java/com/ivyclub/data/ContactRepository.kt
@@ -6,5 +6,6 @@ import com.ivyclub.data.model.GroupData
 interface ContactRepository {
     fun loadFriends(): List<FriendData>
     fun saveFriend(friendData: FriendData)
+    fun loadGroups(): List<GroupData>
     fun saveNewGroup(groupData: GroupData)
 }

--- a/data/src/main/java/com/ivyclub/data/ContactRepository.kt
+++ b/data/src/main/java/com/ivyclub/data/ContactRepository.kt
@@ -1,8 +1,10 @@
 package com.ivyclub.data
 
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.GroupData
 
 interface ContactRepository {
     fun loadFriends(): List<FriendData>
     fun saveFriend(friendData: FriendData)
+    fun saveNewGroup(groupData: GroupData)
 }

--- a/data/src/main/java/com/ivyclub/data/model/ContactData.kt
+++ b/data/src/main/java/com/ivyclub/data/model/ContactData.kt
@@ -25,7 +25,9 @@ data class PlanData(
     val color: String // 고유색, HexCode
 )
 
+@Entity(tableName = "GroupData")
 data class GroupData(
+    @PrimaryKey
     val name: String // 이름, pk
 )
 

--- a/data/src/main/java/com/ivyclub/data/repository/ContactDAO.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactDAO.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.GroupData
 
 @Dao
 interface ContactDAO {
@@ -13,4 +14,7 @@ interface ContactDAO {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertFriendData(friendData: FriendData)
+
+    @Insert
+    fun insertGroupData(groupData: GroupData)
 }

--- a/data/src/main/java/com/ivyclub/data/repository/ContactDAO.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactDAO.kt
@@ -15,6 +15,9 @@ interface ContactDAO {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertFriendData(friendData: FriendData)
 
+    @Query("SELECT * FROM GroupData")
+    fun getGroups(): List<GroupData>
+
     @Insert
     fun insertGroupData(groupData: GroupData)
 }

--- a/data/src/main/java/com/ivyclub/data/repository/ContactDatabase.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactDatabase.kt
@@ -3,8 +3,9 @@ package com.ivyclub.data.repository
 import androidx.room.*
 import com.ivyclub.data.RoomConverters
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.GroupData
 
-@Database(entities = [FriendData::class],version = 1)
+@Database(entities = [FriendData::class, GroupData::class],version = 1)
 @TypeConverters(RoomConverters::class)
 abstract class ContactDatabase: RoomDatabase() {
     abstract fun contactDAO(): ContactDAO

--- a/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
@@ -18,6 +18,10 @@ class ContactRepositoryImpl @Inject constructor(
         contactDAO.insertFriendData(friendData)
     }
 
+    override fun loadGroups(): List<GroupData> {
+        return contactDAO.getGroups()
+    }
+
     override fun saveNewGroup(groupData: GroupData) {
         contactDAO.insertGroupData(groupData)
     }

--- a/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.ivyclub.data.repository
 
 import com.ivyclub.data.ContactRepository
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.GroupData
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -15,5 +16,9 @@ class ContactRepositoryImpl @Inject constructor(
 
     override fun saveFriend(friendData: FriendData) {
         contactDAO.insertFriendData(friendData)
+    }
+
+    override fun saveNewGroup(groupData: GroupData) {
+        contactDAO.insertGroupData(groupData)
     }
 }


### PR DESCRIPTION
## Issue
- close #34 

## Overview (Required)
- 새 그룹 추가 다이얼로그에서 새 그룹 이름을 입력했을 때 중복된 그룹명이 있는지 체크
- `추가` 버튼 클릭 시 room db에 추가

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/87361140/140708261-343aa220-7542-4ad2-aace-ce4cabd6e13a.gif" width="300" />

## 의문점
- dialog의 TextView에 databinding을 적용하려고 할 때 dialog의 레이아웃 xml파일이 따로 있다보니 lifecycleOwner를  FriendFragment로 두게 되었습니다. 이렇게 되면 dialog가 종료되어도 계속 데이터바인딩이 메모리에 남아있게 되고 TextView에 연결되는 변수를 계속 observe하고 있게 되는 게 아닌가라는 의문이 생겼습니다.. 다른 방법이 있을까요?
- 위의 내용에서 이어지는 문제점 같은데, 생명주기가 fragment를 따라가다 보니 다이얼로그의 EditText에 입력 도중에 '취소' 버튼을 누르고 다이얼로그를 종료한 후, 다시 다이얼로그를 띄우면 이전에 입력값이 그대로 EditText에 남아있게 되는 것을 발견했습니다. 지금은 커밋https://github.com/boostcampwm-2021/android03-Contact/commit/dba345c223f5a990fc985f708b5d5206ca4079a6 에서 다이얼로그를 띄우기 전에 EditText를 비우는 방식으로 해결을 했지만 좋은 방법은 아니라는 생각이 들어서 질문 드립니다..!
