### PR TITLE
약속 상세 정보 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     kotlin("android")
     kotlin("kapt")
     id("kotlin-android")
+    id("androidx.navigation.safeargs.kotlin")
     id("dagger.hilt.android.plugin")
 }
 

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan/PlanFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan/PlanFragment.kt
@@ -18,8 +18,7 @@ class PlanFragment : BaseFragment<FragmentPlanBinding>(R.layout.fragment_plan) {
 
     private val planListAdapter: PlanListAdapter by lazy {
         PlanListAdapter {
-            // TODO: 약속 상세 화면 이동
-            Toast.makeText(requireContext(), "plan id : $it", Toast.LENGTH_SHORT).show()
+            findNavController().navigate(PlanFragmentDirections.actionNavigationPlanToPlanDetailsFragment(it))
         }
     }
 

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan/PlanViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan/PlanViewModel.kt
@@ -21,7 +21,7 @@ class PlanViewModel : ViewModel() {
         val startCalendar = Calendar.getInstance()
         startCalendar.set(Calendar.MONTH, 6)
         startCalendar.set(Calendar.DAY_OF_MONTH, 19)
-        val participants = listOf("홍길동", "철수", "영희")
+        val participants = listOf("홍길동", "철수", "영희", "맹구", "태훈")
         repeat(30) {
             val date = Date(startCalendar.timeInMillis + (DAY_IN_MILLIS * 10 * it))
             plans.add(
@@ -31,8 +31,8 @@ class PlanViewModel : ViewModel() {
                         participants,
                         date,
                         "부캠 나들이",
-                        "ㅋㅋㅋ",
-                        ""
+                        content = "ㅋㅋㅋ",
+                        color = ""
                     )
                 )
             )

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
@@ -3,17 +3,37 @@ package com.ivyclub.contact.ui.main.plan_details
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.navArgs
 import com.ivyclub.contact.R
 import com.ivyclub.contact.databinding.FragmentPlanDetailsBinding
 import com.ivyclub.contact.util.BaseFragment
+import com.ivyclub.contact.util.setFriendChips
+import dagger.hilt.android.AndroidEntryPoint
+import java.text.SimpleDateFormat
 
+@AndroidEntryPoint
 class PlanDetailsFragment : BaseFragment<FragmentPlanDetailsBinding>(R.layout.fragment_plan_details) {
 
     private val viewModel: PlanDetailsViewModel by viewModels()
+    private val args: PlanDetailsFragmentArgs by navArgs()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         binding.viewModel = viewModel
+        binding.dateFormat = SimpleDateFormat(getString(R.string.format_simple_date))
+
+        fetchPlanDetails()
+        setObservers()
+    }
+
+    private fun setObservers() {
+        viewModel.planParticipants.observe(viewLifecycleOwner) {
+            binding.cgPlanParticipants.setFriendChips(it)
+        }
+    }
+
+    private fun fetchPlanDetails() {
+        viewModel.getPlanDetails(args.planId)
     }
 }

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
@@ -2,6 +2,7 @@ package com.ivyclub.contact.ui.main.plan_details
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.ivyclub.contact.R
@@ -25,6 +26,14 @@ class PlanDetailsFragment : BaseFragment<FragmentPlanDetailsBinding>(R.layout.fr
 
         fetchPlanDetails()
         setObservers()
+        setEditPlanButton()
+    }
+
+    private fun setEditPlanButton() {
+        binding.ivBtnEditPlan.setOnClickListener {
+            // TODO: 약속 수정 화면 이동
+            Toast.makeText(requireContext(), "edit plan id : ${args.planId}", Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun setObservers() {

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
@@ -1,0 +1,19 @@
+package com.ivyclub.contact.ui.main.plan_details
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.viewModels
+import com.ivyclub.contact.R
+import com.ivyclub.contact.databinding.FragmentPlanDetailsBinding
+import com.ivyclub.contact.util.BaseFragment
+
+class PlanDetailsFragment : BaseFragment<FragmentPlanDetailsBinding>(R.layout.fragment_plan_details) {
+
+    private val viewModel: PlanDetailsViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.viewModel = viewModel
+    }
+}

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsViewModel.kt
@@ -3,8 +3,50 @@ package com.ivyclub.contact.ui.main.plan_details
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ivyclub.data.ContactRepository
+import com.ivyclub.data.model.PlanData
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.sql.Date
+import javax.inject.Inject
 
-class PlanDetailsViewModel : ViewModel() {
+@HiltViewModel
+class PlanDetailsViewModel @Inject constructor(
+    private val repository: ContactRepository
+) : ViewModel() {
 
+    private val _planDetails = MutableLiveData<PlanData>()
+    val planDetails: LiveData<PlanData> = _planDetails
 
+    private val _planParticipants = MutableLiveData<List<String>>()
+    val planParticipants: LiveData<List<String>> = _planParticipants
+
+    fun getPlanDetails(planId: Long) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val planData = repository.getPlanDetailsById(planId)
+            if (planData != null) {
+                val friends = mutableListOf<String>()
+                planData.participant.forEach {
+                    friends.add(repository.getFriendNameByPhoneNumber(it))
+                }
+                _planParticipants.postValue(friends)
+                _planDetails.postValue(planData)
+            } else { // temp
+                val tmpPlanData = PlanData(
+                    0L,
+                    emptyList(),
+                    Date(System.currentTimeMillis()),
+                    "부스트캠프 모임",
+                    "서울시 강남구",
+                    "프로젝트 회의, 저녁식사",
+                    ""
+                )
+                val friends = listOf("홍길동", "철수", "영희", "맹구", "태훈")
+                _planParticipants.postValue(friends)
+                _planDetails.postValue(tmpPlanData)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsViewModel.kt
@@ -1,0 +1,10 @@
+package com.ivyclub.contact.ui.main.plan_details
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class PlanDetailsViewModel : ViewModel() {
+
+
+}

--- a/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListAdapter.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListAdapter.kt
@@ -94,7 +94,7 @@ class PlanListAdapter(
 
             with(binding) {
                 viewModel = itemViewModel
-                cgPlanFriends.setFriendChips(itemViewModel.friends, itemViewModel.friendCount)
+                cgPlanFriends.setFriendChips(itemViewModel.friends, 3)
                 llMonthYear.visibility =
                     if (isHeader(adapterPosition)) View.VISIBLE else View.INVISIBLE
             }

--- a/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListItemViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListItemViewModel.kt
@@ -15,7 +15,5 @@ data class PlanListItemViewModel(private val planData: PlanData) {
     val planDayOfWeek = date.getDayOfWeek().korean
 
     val title: String = planData.title
-    val friendCount = planData.participant.size
     val friends: List<String> = planData.participant
-        .subList(0, 3.coerceAtMost(friendCount))
 }

--- a/app/src/main/java/com/ivyclub/contact/util/DateUtil.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/DateUtil.kt
@@ -5,6 +5,8 @@ import java.util.*
 
 const val DAY_IN_MILLIS = (1000 * 60 * 60 * 24).toLong()
 
+private val calendar: Calendar by lazy { Calendar.getInstance() }
+
 fun Date.getExactYear(): Int = getCalendar(this).get(Calendar.YEAR)
 
 fun Date.getExactMonth(): Int = getCalendar(this).get(Calendar.MONTH) + 1
@@ -16,8 +18,6 @@ fun Date.getDayOfWeek(): DayOfWeek {
 }
 
 private fun getCalendar(date: Date): Calendar {
-    val calendar = Calendar.getInstance()
     calendar.time = date
-
     return calendar
 }

--- a/app/src/main/java/com/ivyclub/contact/util/ViewExtension.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/ViewExtension.kt
@@ -48,17 +48,17 @@ fun ViewDataBinding.hideKeyboard() {
     ViewCompat.getWindowInsetsController(this.root)?.hide(WindowInsetsCompat.Type.ime())
 }
 
-fun ChipGroup.setFriendChips(friendList: List<String>, actualCount: Int) {
+fun ChipGroup.setFriendChips(friendList: List<String>, chipCount: Int = friendList.size) {
     if (isNotEmpty()) removeAllViews()
 
-    friendList.forEachIndexed { index, name ->
+    friendList.subList(0, chipCount.coerceAtMost(friendList.size)).forEachIndexed { index, name ->
         Chip(context).apply {
             text =
-                if (actualCount > 3 && index == 2) {
+                if (friendList.size > chipCount && index == chipCount - 1) {
                     String.format(
                         context.getString(R.string.format_friend_count_etc),
                         name,
-                        actualCount - 3
+                        friendList.size - chipCount
                     )
                 } else {
                     name

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#C4C4C4"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_plan_details.xml
+++ b/app/src/main/res/layout/fragment_plan_details.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+        <variable
+            name="viewModel"
+            type="com.ivyclub.contact.ui.main.plan_details.PlanDetailsViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_plan_details.xml
+++ b/app/src/main/res/layout/fragment_plan_details.xml
@@ -1,16 +1,119 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
         <variable
             name="viewModel"
             type="com.ivyclub.contact.ui.main.plan_details.PlanDetailsViewModel" />
+        <variable
+            name="dateFormat"
+            type="java.text.SimpleDateFormat" />
     </data>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        android:scrollbars="none"
+        android:overScrollMode="never">
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:id="@+id/tv_plan_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="36dp"
+                android:textColor="@color/black"
+                android:textSize="24sp"
+                android:text="@{viewModel.planDetails.title}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="부캠모임" />
+
+            <TextView
+                android:id="@+id/tv_plan_time"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textSize="14sp"
+                tools:text="2021.10.27 10:00 ~ 2021.10.27 12:00"
+                android:text="@{viewModel.planDetails != null ? dateFormat.format(viewModel.planDetails.date) : @string/format_simple_date}"
+                app:layout_constraintStart_toStartOf="@+id/tv_plan_title"
+                app:layout_constraintEnd_toEndOf="@+id/tv_plan_title"
+                app:layout_constraintTop_toBottomOf="@+id/tv_plan_title"/>
+
+            <TextView
+                android:id="@+id/tv_plan_participants"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="32dp"
+                android:text="@string/plan_who"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_plan_time"/>
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/cg_plan_participants"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:minHeight="48dp"
+                android:paddingHorizontal="16dp"
+                app:layout_constraintTop_toBottomOf="@id/tv_plan_participants"
+                app:layout_constraintStart_toStartOf="@+id/tv_plan_participants" />
+
+            <TextView
+                android:id="@+id/tv_plan_where"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/plan_where"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                app:layout_constraintStart_toStartOf="@id/cg_plan_participants"
+                app:layout_constraintTop_toBottomOf="@id/cg_plan_participants"/>
+
+            <TextView
+                android:id="@+id/tv_plan_place"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                tools:text="우리집"
+                android:text="@{viewModel.planDetails.place}"
+                android:lines="1"
+                android:ellipsize="end"
+                app:layout_constraintStart_toStartOf="@id/tv_plan_where"
+                app:layout_constraintTop_toBottomOf="@id/tv_plan_where"/>
+
+            <TextView
+                android:id="@+id/tv_plan_what"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:text="@string/plan_what"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                app:layout_constraintStart_toStartOf="@id/tv_plan_place"
+                app:layout_constraintTop_toBottomOf="@id/tv_plan_place"/>
+
+            <TextView
+                android:id="@+id/tv_plan_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                tools:text="띵까띵까 놀기"
+                android:text="@{viewModel.planDetails.content}"
+                android:lines="1"
+                android:ellipsize="end"
+                app:layout_constraintStart_toStartOf="@id/tv_plan_what"
+                app:layout_constraintTop_toBottomOf="@id/tv_plan_what"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </layout>

--- a/app/src/main/res/layout/fragment_plan_details.xml
+++ b/app/src/main/res/layout/fragment_plan_details.xml
@@ -11,6 +11,7 @@
             name="dateFormat"
             type="java.text.SimpleDateFormat" />
     </data>
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -21,6 +22,16 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/iv_btn_edit_plan"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="8dp"
+                android:layout_margin="16dp"
+                android:src="@drawable/ic_edit"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"/>
 
             <TextView
                 android:id="@+id/tv_plan_title"

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -26,12 +26,7 @@
             app:destination="@id/settingsFragment" />
         <action
             android:id="@+id/action_navigation_plan_to_planDetailsFragment"
-            app:destination="@id/planDetailsFragment">
-            <argument
-                android:name="planId"
-                app:argType="long"
-                android:defaultValue="0L"/>
-        </action>
+            app:destination="@id/planDetailsFragment"/>
     </fragment>
 
     <fragment
@@ -44,7 +39,12 @@
         android:id="@+id/planDetailsFragment"
         android:name="com.ivyclub.contact.ui.main.plan_details.PlanDetailsFragment"
         android:label="PlanDetailsFragment"
-        tools:layout="@layout/fragment_plan_details"/>
+        tools:layout="@layout/fragment_plan_details">
+        <argument
+            android:name="planId"
+            app:argType="long"
+            android:defaultValue="0L" />
+    </fragment>
 
     <fragment
         android:id="@+id/settingsFragment"

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -24,6 +24,14 @@
         <action
             android:id="@+id/action_navigation_plan_to_settingsFragment"
             app:destination="@id/settingsFragment" />
+        <action
+            android:id="@+id/action_navigation_plan_to_planDetailsFragment"
+            app:destination="@id/planDetailsFragment">
+            <argument
+                android:name="planId"
+                app:argType="long"
+                android:defaultValue="0L"/>
+        </action>
     </fragment>
 
     <fragment
@@ -31,6 +39,13 @@
         android:name="com.ivyclub.contact.ui.main.add_friend.AddFriendFragment"
         android:label="AddFriendFragment"
         tools:layout="@layout/fragment_add_friend"/>
+
+    <fragment
+        android:id="@+id/planDetailsFragment"
+        android:name="com.ivyclub.contact.ui.main.plan_details.PlanDetailsFragment"
+        android:label="PlanDetailsFragment"
+        tools:layout="@layout/fragment_plan_details"/>
+
     <fragment
         android:id="@+id/settingsFragment"
         android:name="com.ivyclub.contact.ui.main.settings.SettingsFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,8 @@
     <string name="format_month">%d월</string>
     <string name="format_date_day">%d일 %s요일</string>
     <string name="format_friend_count_etc">%s 외 %d명</string>
+    <string name="format_simple_date">yyyy년 MM월 dd일 HH시 mm분</string>
+    <string name="plan_what">약속 내용</string>
+    <string name="plan_where">어디서</string>
+    <string name="plan_who">누구랑</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ buildscript {
         classpath("com.android.tools.build:gradle:7.0.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
         classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.hilt}")
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.navigation}")
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/data/src/main/java/com/ivyclub/data/ContactRepository.kt
+++ b/data/src/main/java/com/ivyclub/data/ContactRepository.kt
@@ -1,8 +1,12 @@
 package com.ivyclub.data
 
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.PlanData
 
 interface ContactRepository {
     fun loadFriends(): List<FriendData>
     fun saveFriend(friendData: FriendData)
+
+    fun getPlanDetailsById(planId: Long): PlanData
+    fun getFriendNameByPhoneNumber(phoneNumber: String): String
 }

--- a/data/src/main/java/com/ivyclub/data/RoomConverters.kt
+++ b/data/src/main/java/com/ivyclub/data/RoomConverters.kt
@@ -3,6 +3,7 @@ package com.ivyclub.data
 import androidx.room.TypeConverter
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import java.sql.Date
 import java.util.*
 
 class RoomConverters {
@@ -20,4 +21,10 @@ class RoomConverters {
         val mapType = object : TypeToken<Map<String?, String?>?>() {}.type
         return Gson().fromJson(value, mapType)
     }
+
+    @TypeConverter
+    fun dateToLong(value: Date) = value.time
+
+    @TypeConverter
+    fun longToDate(value: Long) = Date(value)
 }

--- a/data/src/main/java/com/ivyclub/data/model/ContactData.kt
+++ b/data/src/main/java/com/ivyclub/data/model/ContactData.kt
@@ -16,12 +16,15 @@ data class FriendData(
     val extraInfo: Map<String, String> // 성격
 )
 
+@Entity(tableName = "PlanData")
 data class PlanData(
+    @PrimaryKey
     val id: Long, // 약속 ID, pk
-    val participant: List<String>, // 만나는 사람들(번호)
+    val participant: List<String> = emptyList(), // 만나는 사람들(번호)
     val date: Date, // datetime
-    val title: String, // 제목
-    val content: String, // 내용
+    val title: String = "", // 제목
+    val place: String = "", // 장소
+    val content: String = "", // 내용
     val color: String // 고유색, HexCode
 )
 

--- a/data/src/main/java/com/ivyclub/data/repository/ContactDAO.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactDAO.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.PlanData
 
 @Dao
 interface ContactDAO {
@@ -13,4 +14,10 @@ interface ContactDAO {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertFriendData(friendData: FriendData)
+
+    @Query("SELECT * FROM PlanData WHERE id = :planId")
+    fun getPlanDetailsById(planId: Long): PlanData
+
+    @Query("SELECT name FROM FriendData WHERE phoneNumber = :phoneNumber")
+    fun getFriendNameByPhoneNumber(phoneNumber: String): String
 }

--- a/data/src/main/java/com/ivyclub/data/repository/ContactDatabase.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactDatabase.kt
@@ -3,8 +3,9 @@ package com.ivyclub.data.repository
 import androidx.room.*
 import com.ivyclub.data.RoomConverters
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.PlanData
 
-@Database(entities = [FriendData::class],version = 1)
+@Database(entities = [FriendData::class, PlanData::class],version = 1)
 @TypeConverters(RoomConverters::class)
 abstract class ContactDatabase: RoomDatabase() {
     abstract fun contactDAO(): ContactDAO

--- a/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
@@ -25,6 +25,7 @@ class ContactRepositoryImpl @Inject constructor(
 
     override fun getFriendNameByPhoneNumber(phoneNumber: String): String {
         return contactDAO.getFriendNameByPhoneNumber(phoneNumber)
+    }
     
     override fun loadGroups(): List<GroupData> {
         return contactDAO.getGroups()

--- a/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.ivyclub.data.repository
 
 import com.ivyclub.data.ContactRepository
 import com.ivyclub.data.model.FriendData
+import com.ivyclub.data.model.PlanData
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -15,5 +16,13 @@ class ContactRepositoryImpl @Inject constructor(
 
     override fun saveFriend(friendData: FriendData) {
         contactDAO.insertFriendData(friendData)
+    }
+
+    override fun getPlanDetailsById(planId: Long): PlanData {
+        return contactDAO.getPlanDetailsById(planId)
+    }
+
+    override fun getFriendNameByPhoneNumber(phoneNumber: String): String {
+        return contactDAO.getFriendNameByPhoneNumber(phoneNumber)
     }
 }


### PR DESCRIPTION
## Issue
- #35 

## Overview (Required)
- [x] 약속 상세 정보 레이아웃 작성
- [x] 약속 정보 화면에 반영
- [x] 약속 정보 Room DB 테이블 적용
- [x] 약속 id로 약속 상세 정보 조회 및 전화번호로 지인 이름 조회 기능 DAO에 추가 
- [ ] RoomDB 에서 약속데이터를 불러와 화면에 표시 (아직 약속 추가 기능 구현이 안돼있어서 실제 데이터로 테스트 못함)

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/48874574/140721046-750b0b84-54a9-4e18-8a19-97c63e51fc9a.png" width="300" />
