### PR TITLE
약속 상세정보 화면 삭제 기능 추가

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanFragment.kt
@@ -60,9 +60,6 @@ class AddEditPlanFragment :
             ivBtnEditPlanFinish.setOnClickListener {
                 showSavePlanDialog()
             }
-            ivBtnDeletePlan.setOnClickListener {
-                showDeletePlanDialog()
-            }
             tvPlanTime.setOnClickListener {
                 this@AddEditPlanFragment.viewModel.planTime.value?.let {
                     showDatePickerDialog(it)
@@ -101,12 +98,6 @@ class AddEditPlanFragment :
     private fun showSavePlanDialog() {
         context?.showAlertDialog(getString(R.string.ask_save_plan), {
             viewModel.savePlan()
-        })
-    }
-
-    private fun showDeletePlanDialog() {
-        context?.showAlertDialog(getString(R.string.ask_delete_plan), {
-            viewModel.deletePlan()
         })
     }
 

--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
@@ -131,18 +131,6 @@ class AddEditPlanViewModel @Inject constructor(
         }
     }
 
-    fun deletePlan() {
-        if (planId == -1L) {
-            finish()
-            return
-        }
-        viewModelScope.launch(Dispatchers.IO) {
-            repository.deletePlanData(planId)
-            makeToast(R.string.delete_plan_success)
-            finish()
-        }
-    }
-
     private fun makeToast(strId: Int) {
         _toastMessage.postValue(strId)
     }

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
@@ -34,14 +34,14 @@ class PlanDetailsFragment :
 
     private fun setEditPlanButton() {
         with(binding) {
-            binding.ivBtnEditPlan.setOnClickListener {
+            ivBtnEditPlan.setOnClickListener {
                 findNavController().navigate(
                     PlanDetailsFragmentDirections.actionPlanDetailsFragmentToAddEditFragment(
                         args.planId
                     )
                 )
             }
-            binding.ivBtnDeletePlan.setOnClickListener {
+            ivBtnDeletePlan.setOnClickListener {
                 showDeletePlanDialog()
             }
         }

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
@@ -2,6 +2,7 @@ package com.ivyclub.contact.ui.main.plan_details
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -9,6 +10,7 @@ import com.ivyclub.contact.R
 import com.ivyclub.contact.databinding.FragmentPlanDetailsBinding
 import com.ivyclub.contact.util.BaseFragment
 import com.ivyclub.contact.util.setFriendChips
+import com.ivyclub.contact.util.showAlertDialog
 import dagger.hilt.android.AndroidEntryPoint
 import java.text.SimpleDateFormat
 
@@ -31,18 +33,38 @@ class PlanDetailsFragment :
     }
 
     private fun setEditPlanButton() {
-        binding.ivBtnEditPlan.setOnClickListener {
-            findNavController().navigate(
-                PlanDetailsFragmentDirections.actionPlanDetailsFragmentToAddEditFragment(
-                    args.planId
+        with(binding) {
+            binding.ivBtnEditPlan.setOnClickListener {
+                findNavController().navigate(
+                    PlanDetailsFragmentDirections.actionPlanDetailsFragmentToAddEditFragment(
+                        args.planId
+                    )
                 )
-            )
+            }
+            binding.ivBtnDeletePlan.setOnClickListener {
+                showDeletePlanDialog()
+            }
         }
+    }
+
+    private fun showDeletePlanDialog() {
+        context?.showAlertDialog(getString(R.string.ask_delete_plan), {
+            viewModel.deletePlan()
+        })
     }
 
     private fun setObservers() {
         viewModel.planParticipants.observe(viewLifecycleOwner) {
             binding.cgPlanParticipants.setFriendChips(it)
+        }
+
+        viewModel.toastMessage.observe(viewLifecycleOwner) {
+            if (context == null) return@observe
+            Toast.makeText(context, getString(it), Toast.LENGTH_SHORT).show()
+        }
+
+        viewModel.finishEvent.observe(viewLifecycleOwner) {
+            findNavController().popBackStack()
         }
     }
 

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsViewModel.kt
@@ -33,14 +33,13 @@ class PlanDetailsViewModel @Inject constructor(
     fun getPlanDetails(planId: Long) {
         viewModelScope.launch(Dispatchers.IO) {
             val planData = repository.getPlanDataById(planId)
-            if (planData != null) {
-                val friends = mutableListOf<String>()
-                planData.participant.forEach {
-                    friends.add(repository.getSimpleFriendDataById(it).name)
-                }
-                _planParticipants.postValue(friends)
-                _planDetails.postValue(planData)
+
+            val friends = mutableListOf<String>()
+            planData.participant.forEach {
+                friends.add(repository.getSimpleFriendDataById(it).name)
             }
+            _planParticipants.postValue(friends)
+            _planDetails.postValue(planData)
         }
     }
 
@@ -48,7 +47,7 @@ class PlanDetailsViewModel @Inject constructor(
         val planData = planDetails.value ?: return
 
         viewModelScope.launch(Dispatchers.IO) {
-            //repository.deletePlanData(planData)
+            repository.deletePlanData(planData)
             makeToast(R.string.delete_plan_success)
             finish()
         }
@@ -58,7 +57,7 @@ class PlanDetailsViewModel @Inject constructor(
         _toastMessage.postValue(strId)
     }
 
-    fun finish() {
+    private fun finish() {
         _finishEvent.call()
     }
 }

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsViewModel.kt
@@ -4,12 +4,13 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.ivyclub.contact.R
+import com.ivyclub.contact.util.SingleLiveEvent
 import com.ivyclub.data.ContactRepository
 import com.ivyclub.data.model.PlanData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.sql.Date
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,6 +24,12 @@ class PlanDetailsViewModel @Inject constructor(
     private val _planParticipants = MutableLiveData<List<String>>()
     val planParticipants: LiveData<List<String>> = _planParticipants
 
+    private val _toastMessage = SingleLiveEvent<Int>()
+    val toastMessage: LiveData<Int> = _toastMessage
+
+    private val _finishEvent = SingleLiveEvent<Unit>()
+    val finishEvent: LiveData<Unit> = _finishEvent
+
     fun getPlanDetails(planId: Long) {
         viewModelScope.launch(Dispatchers.IO) {
             val planData = repository.getPlanDataById(planId)
@@ -35,5 +42,23 @@ class PlanDetailsViewModel @Inject constructor(
                 _planDetails.postValue(planData)
             }
         }
+    }
+
+    fun deletePlan() {
+        val planData = planDetails.value ?: return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            //repository.deletePlanData(planData)
+            makeToast(R.string.delete_plan_success)
+            finish()
+        }
+    }
+
+    private fun makeToast(strId: Int) {
+        _toastMessage.postValue(strId)
+    }
+
+    fun finish() {
+        _finishEvent.call()
     }
 }

--- a/app/src/main/res/layout/fragment_add_edit_plan.xml
+++ b/app/src/main/res/layout/fragment_add_edit_plan.xml
@@ -32,16 +32,6 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
 
-            <ImageView
-                android:id="@+id/iv_btn_delete_plan"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:padding="4dp"
-                android:layout_margin="16dp"
-                android:src="@drawable/ic_delete"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"/>
-
             <EditText
                 android:id="@+id/et_plan_title"
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_plan_details.xml
+++ b/app/src/main/res/layout/fragment_plan_details.xml
@@ -87,6 +87,7 @@
                 android:layout_marginTop="8dp"
                 android:minHeight="48dp"
                 android:paddingHorizontal="16dp"
+                app:chipSpacingVertical="4dp"
                 app:layout_constraintTop_toBottomOf="@id/tv_plan_participants"
                 app:layout_constraintStart_toStartOf="@+id/tv_plan_participants" />
 

--- a/app/src/main/res/layout/fragment_plan_details.xml
+++ b/app/src/main/res/layout/fragment_plan_details.xml
@@ -33,6 +33,16 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"/>
 
+            <ImageView
+                android:id="@+id/iv_btn_delete_plan"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="4dp"
+                android:layout_margin="16dp"
+                android:src="@drawable/ic_delete"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"/>
+
             <TextView
                 android:id="@+id/tv_plan_title"
                 android:layout_width="wrap_content"

--- a/data/src/main/java/com/ivyclub/data/ContactRepository.kt
+++ b/data/src/main/java/com/ivyclub/data/ContactRepository.kt
@@ -12,7 +12,7 @@ interface ContactRepository {
     fun getPlanList(): List<SimplePlanData>
     fun getPlanDataById(planId: Long): PlanData
     fun savePlanData(planData: PlanData, lastParticipants: List<Long> = emptyList())
-    fun deletePlanData(planId: Long)
+    fun deletePlanData(planData: PlanData)
     fun getSimpleFriendDataListByGroup(groupName: String): List<SimpleFriendData>
     fun getSimpleFriendDataById(friendId: Long): SimpleFriendData
     fun getSimpleFriendData(): List<SimpleFriendData>

--- a/data/src/main/java/com/ivyclub/data/repository/ContactDAO.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactDAO.kt
@@ -32,8 +32,8 @@ interface ContactDAO {
     @Query("SELECT id, name, phoneNumber FROM FriendData WHERE groupName = :groupName")
     fun getSimpleFriendDataListByGroup(groupName: String): List<SimpleFriendData>
 
-    @Query("DELETE FROM PlanData WHERE id = :planId")
-    fun deletePlanData(planId: Long)
+    @Delete
+    fun deletePlanData(planData: PlanData)
 
     @Query("SELECT id, name, phoneNumber FROM FriendData WHERE id = :friendId")
     fun getSimpleFriendDataById(friendId: Long): SimpleFriendData

--- a/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
+++ b/data/src/main/java/com/ivyclub/data/repository/ContactRepositoryImpl.kt
@@ -65,8 +65,13 @@ class ContactRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun deletePlanData(planId: Long) {
-        contactDAO.deletePlanData(planId)
+    override fun deletePlanData(planData: PlanData) {
+        contactDAO.deletePlanData(planData)
+        planData.participant.forEach { friendId ->
+            val planSet = contactDAO.getFriendsPlanList(friendId).planList.toMutableSet()
+            planSet.remove(planData.id)
+            contactDAO.updateFriendsPlanList(friendId, planSet.toList())
+        }
     }
 
     override fun getSimpleFriendDataListByGroup(groupName: String): List<SimpleFriendData> {


### PR DESCRIPTION
## Issue
- close #76 

## Overview (Required)
- 약속 추가/수정 화면의 삭제 기능을 약속 상세정보 화면으로 이동
- 약속 삭제시 참여 지인 정보에도 해당 약속 삭제되도록 기능 수정

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/48874574/141247092-12928406-212b-4f28-9734-9a4997b225e7.png" width="300" /> | <img src="https://user-images.githubusercontent.com/48874574/141247198-bd612c3c-b1d8-4cb8-a9a5-ac3417553843.png" width="300" />
<img src="https://user-images.githubusercontent.com/48874574/141247923-117d53b5-78f3-40ea-ba3c-48500f66a62c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/48874574/141247712-5637264a-c27c-4431-8d63-b228b9b4878c.png" width="300" />
