### PR TITLE
연락처가 많은 경우 다 가져와지지 않는 버그 해결

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/AddContactFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/AddContactFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.view.animation.AnimationUtils
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
@@ -22,6 +23,7 @@ import com.ivyclub.contact.ui.onboard.contact.dialog.DialogGetContactsLoadingFra
 import com.ivyclub.contact.util.BaseFragment
 import com.ivyclub.contact.util.SkipDialog
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
 
 @AndroidEntryPoint
 class AddContactFragment : BaseFragment<FragmentAddContactBinding>(R.layout.fragment_add_contact) {
@@ -123,12 +125,14 @@ class AddContactFragment : BaseFragment<FragmentAddContactBinding>(R.layout.frag
     }
 
     private fun observeSavingDone() {
-        viewModel.isSavingDone.observe(viewLifecycleOwner) { isDone ->
-            if (isDone) {
-                loadingDialog.dismiss()
-                val intent = Intent(context, MainActivity::class.java)
-                activity?.setResult(RESULT_OK, intent)
-                activity?.finish()
+        lifecycleScope.launchWhenStarted {
+            viewModel.isSavingDone.collectLatest { isDone ->
+                if (isDone) {
+                    loadingDialog.dismiss()
+                    val intent = Intent(context, MainActivity::class.java)
+                    activity?.setResult(RESULT_OK, intent)
+                    activity?.finish()
+                }
             }
         }
     }

--- a/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/AddContactFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/AddContactFragment.kt
@@ -18,6 +18,7 @@ import com.ivyclub.contact.R
 import com.ivyclub.contact.databinding.FragmentAddContactBinding
 import com.ivyclub.contact.model.PhoneContactData
 import com.ivyclub.contact.ui.main.MainActivity
+import com.ivyclub.contact.ui.onboard.contact.dialog.DialogGetContactsLoadingFragment
 import com.ivyclub.contact.util.BaseFragment
 import com.ivyclub.contact.util.SkipDialog
 import dagger.hilt.android.AndroidEntryPoint
@@ -29,6 +30,7 @@ class AddContactFragment : BaseFragment<FragmentAddContactBinding>(R.layout.frag
     private lateinit var contactList: MutableList<PhoneContactData>
     private val viewModel: AddContactViewModel by viewModels()
     private val navController by lazy { findNavController() }
+    private val loadingDialog = DialogGetContactsLoadingFragment()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -45,6 +47,7 @@ class AddContactFragment : BaseFragment<FragmentAddContactBinding>(R.layout.frag
         initRecyclerView()
         initButtons()
         initAppBar()
+        observeSavingDone()
     }
 
     private fun initRecyclerView() {
@@ -58,9 +61,10 @@ class AddContactFragment : BaseFragment<FragmentAddContactBinding>(R.layout.frag
         }
         btnCommit.setOnClickListener {
             viewModel.saveFriendsData(contactAdapter.addSet.toMutableList())
-            val intent = Intent(context, MainActivity::class.java)
-            activity?.setResult(RESULT_OK, intent)
-            activity?.finish()
+            loadingDialog.show(
+                childFragmentManager,
+                DialogGetContactsLoadingFragment.TAG
+            ) // 로딩 다이얼로그 보여주기
         }
         btnCommit.isClickable = false
     }
@@ -118,4 +122,14 @@ class AddContactFragment : BaseFragment<FragmentAddContactBinding>(R.layout.frag
         activity?.finish()
     }
 
+    private fun observeSavingDone() {
+        viewModel.isSavingDone.observe(viewLifecycleOwner) { isDone ->
+            if (isDone) {
+                loadingDialog.dismiss()
+                val intent = Intent(context, MainActivity::class.java)
+                activity?.setResult(RESULT_OK, intent)
+                activity?.finish()
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/AddContactViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/AddContactViewModel.kt
@@ -1,5 +1,7 @@
 package com.ivyclub.contact.ui.onboard.contact
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ivyclub.contact.model.PhoneContactData
@@ -16,6 +18,9 @@ class AddContactViewModel @Inject constructor(
     private val contactListManager: ContactListManager
 ) : ViewModel() {
 
+    private val _isSavingDone = MutableLiveData(false)
+    val isSavingDone: LiveData<Boolean> get() = _isSavingDone
+
     fun saveFriendsData(data: List<PhoneContactData>) {
         viewModelScope.launch {
             data.forEach {
@@ -31,6 +36,7 @@ class AddContactViewModel @Inject constructor(
                     )
                 )
             }
+            _isSavingDone.value = true
         }
     }
 

--- a/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/AddContactViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/AddContactViewModel.kt
@@ -1,7 +1,5 @@
 package com.ivyclub.contact.ui.onboard.contact
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ivyclub.contact.model.PhoneContactData
@@ -9,6 +7,8 @@ import com.ivyclub.contact.util.ContactListManager
 import com.ivyclub.data.ContactRepository
 import com.ivyclub.data.model.FriendData
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -18,8 +18,9 @@ class AddContactViewModel @Inject constructor(
     private val contactListManager: ContactListManager
 ) : ViewModel() {
 
-    private val _isSavingDone = MutableLiveData(false)
-    val isSavingDone: LiveData<Boolean> get() = _isSavingDone
+    // one-shot event로 추후 개선이 필요
+    private val _isSavingDone = MutableStateFlow(false)
+    val isSavingDone = _isSavingDone.asStateFlow()
 
     fun saveFriendsData(data: List<PhoneContactData>) {
         viewModelScope.launch {

--- a/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/dialog/DialogGetContactsLoadingFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/onboard/contact/dialog/DialogGetContactsLoadingFragment.kt
@@ -1,0 +1,35 @@
+package com.ivyclub.contact.ui.onboard.contact.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
+import com.ivyclub.contact.R
+import com.ivyclub.contact.databinding.FragmentDialogGetContactsLoadingBinding
+
+class DialogGetContactsLoadingFragment : DialogFragment() {
+    private lateinit var binding: FragmentDialogGetContactsLoadingBinding
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        isCancelable = false
+    }
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = DataBindingUtil.inflate(
+            inflater,
+            R.layout.fragment_dialog_get_contacts_loading,
+            container,
+            false
+        )
+        return binding.root
+    }
+
+    companion object {
+        const val TAG = "DIALOG_GET_CONTACTS_LOADING_FRAGMENT"
+    }
+}

--- a/app/src/main/res/layout/fragment_dialog_get_contacts_loading.xml
+++ b/app/src/main/res/layout/fragment_dialog_get_contacts_loading.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:padding="20dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <ProgressBar
+            android:id="@+id/pg_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:text="@string/fragment_dialog_get_contacts_loading_please_wait"
+            android:textColor="@color/black"
+            app:layout_constraintBottom_toBottomOf="@id/pg_loading"
+            app:layout_constraintStart_toEndOf="@id/pg_loading"
+            app:layout_constraintTop_toTopOf="@id/pg_loading" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,5 @@
     <string name="group_name_validation_wrong_empty">한글자 이상 입력해주세요.</string>
     <string name="group_name_validation_wrong_duplicate">이미 존재하는 그룹 이름입니다.</string>
     <string name="empty_string" />
+    <string name="fragment_dialog_get_contacts_loading_please_wait">잠시만 기다려주세요.</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #124 

## Overview (Required)
- 앱을 처음 실행하고 연락처 불러오기를 했을 때, 연락처가 많으면 다 불러와지지 않는 버그 수정

## Screenshot
에뮬레이터에는 연락처가 너무 적어서 로딩 화면이 거의 없이 빨리 넘어갑니다.
그래서 로딩 화면에서 멈추도록 임시로 만들었습니다. 실제로 사용해보시면 넘어갑니다.
Before | After
:--: | :--:
<img src="" width="300" /> | <video src="https://user-images.githubusercontent.com/57510192/142188640-b2ce99bf-0320-4bc0-bc3a-f9059f2b0397.mp4" width="300" />
