### PR TITLE
[FIX] #141 - 위젯 활성화시 약속 데이터 갱신 안되는 버그 수정

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanFragment.kt
@@ -4,7 +4,6 @@ import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -98,7 +97,6 @@ class AddEditPlanFragment :
 
     private fun showSavePlanDialog() {
         context?.showAlertDialog(getString(R.string.ask_save_plan), {
-            WidgetProvider.sendRefreshBroadcast(context!!)
             viewModel.savePlan()
         })
     }

--- a/app/src/main/java/com/ivyclub/contact/util/MyRemoteViewsFactory.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/MyRemoteViewsFactory.kt
@@ -3,12 +3,11 @@ package com.ivyclub.contact.util
 import android.content.Context
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
-import com.ivyclub.data.model.SimplePlanData
 import com.ivyclub.contact.R
 import com.ivyclub.data.ContactRepository
+import com.ivyclub.data.model.SimplePlanData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import java.sql.Date
@@ -18,7 +17,7 @@ class MyRemoteViewsFactory(
     private val repository: ContactRepository
 ) : RemoteViewsService.RemoteViewsFactory {
 
-    private val data = mutableListOf<SimplePlanData>()
+    private var data = emptyList<SimplePlanData>()
 
     init {
         CoroutineScope(Dispatchers.IO).launch {
@@ -29,12 +28,16 @@ class MyRemoteViewsFactory(
     private suspend fun getPlanListForWidget() {
         val current = Date(System.currentTimeMillis())
 
-        repository.loadPlanListWithFlow().buffer().collect { newPlanList ->
-            data.clear()
-            data.addAll(newPlanList.filter {
+        repository.loadPlanListWithFlow().collect { newPlanList ->
+            val tmpList = newPlanList.filter {
                 it.date.getExactYear() == current.getExactYear() &&
-                    it.date.getExactMonth() == current.getExactMonth()
-            })
+                        it.date.getExactMonth() == current.getExactMonth()
+            }
+
+            if (data != tmpList) {
+                data = tmpList
+                WidgetProvider.sendRefreshBroadcast(context)
+            }
         }
     }
 

--- a/app/src/main/java/com/ivyclub/contact/util/MyRemoteViewsFactory.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/MyRemoteViewsFactory.kt
@@ -6,10 +6,8 @@ import android.widget.RemoteViewsService
 import com.ivyclub.contact.R
 import com.ivyclub.data.ContactRepository
 import com.ivyclub.data.model.SimplePlanData
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import java.sql.Date
 
 class MyRemoteViewsFactory(
@@ -19,11 +17,10 @@ class MyRemoteViewsFactory(
 
     private var data = emptyList<SimplePlanData>()
 
-    init {
-        CoroutineScope(Dispatchers.IO).launch {
+    private val refreshingJob: Job =
+        CoroutineScope(Dispatchers.IO).launch(start = CoroutineStart.LAZY) {
             getPlanListForWidget()
         }
-    }
 
     private suspend fun getPlanListForWidget() {
         val current = Date(System.currentTimeMillis())
@@ -44,9 +41,7 @@ class MyRemoteViewsFactory(
     override fun onCreate() {}
 
     override fun onDataSetChanged() {
-        CoroutineScope(Dispatchers.IO).launch {
-            getPlanListForWidget()
-        }
+        if (!refreshingJob.isActive) refreshingJob.start()
     }
 
     override fun onDestroy() {}


### PR DESCRIPTION
## Issue
- close #141 

## Overview (Required)
- 약속 위젯 열 때 리스트 갱신 안되는 버그 해결하기
    - flow가 갱신될 때 기존 리스트와 달라지면 `WidgetProvider.sendRefreshBroadcast()`을 호출하는 방법으로 변경했습니다.

## Screenshot
https://user-images.githubusercontent.com/48874574/142355361-d79fff75-039a-46d4-8b64-f3f971014a6a.mp4
