### PR TITLE
[FIX] - 설정 화면에서 알림 시간 설정 완료시 dialog 내리기

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/settings/dialog/NotificationTimeDialogViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/settings/dialog/NotificationTimeDialogViewModel.kt
@@ -60,6 +60,8 @@ class NotificationTimeDialogViewModel @Inject constructor(
                         workManager
                     )
             }
+
+            _changeNotiTimeFinishEvent.call()
         }
     }
 }


### PR DESCRIPTION
## Overview (Required)
- 설정 화면에서 알림 시간 설정 완료시 dialog가 안닫히는 버그 수정
