### PR TITLE
위젯 클릭 관련 버그 수정, 약속 상세 화면 수정

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
@@ -56,10 +56,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     override fun onResume() {
         super.onResume()
         viewModel.checkPasswordOnResume()
-        if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0) {
-            checkFromNotification()
-            checkFromWidget()
-        }
+        checkFromNotification()
+        checkFromWidget()
     }
 
     private fun checkFromNotification() {
@@ -75,6 +73,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                                 planId
                             )
                         )
+                        resetIntent(NOTIFICATION, NOTI_PLAN_ID)
                     }
                 }
             }
@@ -89,7 +88,14 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                     widgetPlanId
                 )
             )
+            resetIntent(WIDGET_PLAN_ID)
         }
+    }
+
+    private fun resetIntent(vararg keys: String) {
+        val i = intent
+        keys.forEach { key -> i.removeExtra(key) }
+        intent = i
     }
 
     private fun setOnBoardingResult() {

--- a/app/src/main/java/com/ivyclub/contact/ui/main/friend_detail/FriendDetailFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/friend_detail/FriendDetailFragment.kt
@@ -58,6 +58,13 @@ class FriendDetailFragment :
         viewModel.groupName.observe(viewLifecycleOwner) {
             binding.tvGroup.text = it
         }
+        viewModel.goPlanDetailsEvent.observe(viewLifecycleOwner) {
+            findNavController().navigate(
+                FriendDetailFragmentDirections.actionFriendDetailFragmentToPlanDetailsFragment(
+                    it
+                )
+            )
+        }
     }
 
     private fun initButtons(id: Long) {
@@ -135,7 +142,7 @@ class FriendDetailFragment :
                 val intent = Intent(Intent.ACTION_DIAL, Uri.parse("tel:${friend.phoneNumber}"))
                 startActivity(intent)
             }
-            bindPlan(friend.planList)
+//            bindPlan(friend.planList)
         }
 
     }
@@ -169,9 +176,9 @@ class FriendDetailFragment :
         }
     }
 
-    private fun bindPlan(planIds: List<Long>) {
-        viewModel.loadPlans(planIds)
-    }
+//    private fun bindPlan(planIds: List<Long>) {
+//        viewModel.loadPlans(planIds)
+//    }
 
     private fun showDeleteFriendDialog() {
         context?.showAlertDialog(getString(R.string.ask_delete_friend), {

--- a/app/src/main/res/layout/fragment_friend_detail.xml
+++ b/app/src/main/res/layout/fragment_friend_detail.xml
@@ -240,7 +240,8 @@
                     android:background="@drawable/bg_plan"
                     android:orientation="vertical"
                     android:paddingHorizontal="16dp"
-                    android:visibility="@{viewModel.plan1Exist ? View.VISIBLE : View.GONE}"
+                    android:onClick="@{()->viewModel.goPlanDetails(viewModel.plan1.id)}"
+                    android:visibility="@{viewModel.friendData.planList.size >= 1 ? View.VISIBLE : View.GONE}"
                     app:layout_constraintTop_toBottomOf="@id/tv_plan_text">
 
                     <TextView
@@ -272,7 +273,8 @@
                     android:background="@drawable/bg_plan"
                     android:orientation="vertical"
                     android:paddingHorizontal="16dp"
-                    android:visibility="@{viewModel.plan2Exist ? View.VISIBLE : View.GONE}"
+                    android:onClick="@{()->viewModel.goPlanDetails(viewModel.plan2.id)}"
+                    android:visibility="@{viewModel.friendData.planList.size == 2 ? View.VISIBLE : View.GONE}"
                     app:layout_constraintTop_toBottomOf="@id/ll_plan1">
 
                     <TextView

--- a/app/src/main/res/layout/fragment_plan_details.xml
+++ b/app/src/main/res/layout/fragment_plan_details.xml
@@ -64,8 +64,9 @@
         <ScrollView
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:paddingBottom="32dp"
+            android:clipToPadding="false"
             android:fillViewport="true"
-            android:scrollbars="none"
             android:overScrollMode="never"
             app:layout_constraintTop_toBottomOf="@id/cl_toolbar"
             app:layout_constraintBottom_toBottomOf="parent">
@@ -161,14 +162,12 @@
 
                 <TextView
                     android:id="@+id/tv_plan_description"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:layout_marginHorizontal="16dp"
                     tools:text="띵까띵까 놀기"
                     android:text="@{viewModel.planDetails.content}"
-                    android:lines="1"
-                    android:ellipsize="end"
-                    app:layout_constraintStart_toStartOf="@id/tv_plan_what"
                     app:layout_constraintTop_toBottomOf="@id/tv_plan_what"/>
             </androidx.constraintlayout.widget.ConstraintLayout>
         </ScrollView>

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation(Dep.AndroidX.core)
     implementation(Dep.AndroidX.appcompat)
     implementation(Dep.AndroidX.material)
-    implementation(Dep.AndroidX.roomRuntime)
+    api(Dep.AndroidX.roomRuntime)
     implementation(Dep.AndroidX.sharedPreference)
     implementation(Dep.Libs.gson)
     implementation(Dep.Libs.hilt)


### PR DESCRIPTION
## Issue
- close #217 
- close #218 

## Overview (Required)
- MainActivity에 `resetIntent()` 메소드를 추가하여 위젯/푸시 알림 클릭 후 MainActivity의 intent가 초기화되지 않아 지인 리스트 화면에 다리 onResume()이 호출될 때 자동으로 약속 상세 화면으로 이동되는 버그 수정
- 약속 상세 화면의 내용 TextView의 속성 변경 (1줄 -> 여러줄)
- 약속 상세 화면 Scrollbar 속성 변경 (paddingBottom 적용, scrollbar 보이게)
