### PR TITLE
password lock 시점 변경

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
@@ -40,11 +40,6 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         setOnPasswordResult()
     }
 
-    override fun onPause() {
-        super.onPause()
-        viewModel.lock()
-    }
-
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         setIntent(intent)
@@ -55,6 +50,11 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
         viewModel.checkPasswordOnResume()
         checkFromNotification()
         checkFromWidget()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.lock()
     }
 
     private fun checkFromNotification() {


### PR DESCRIPTION
## Issue
- close #249 

## Overview (Required)
- password lock 시점이 원래 onPause였는데 onStop으로 변경
   -> 다이얼로그를 띄우고 돌아올 때나, 멀티스크린 모드에서 focus를 잃었다가 다시 얻었을 때 다시 비밀번호 확인을 하지 않도록




