### PR TITLE
언어 변경 시 약속 리스트 아이템 요일 언어 변경이 되지 않는 이슈

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/service/ContactRemoteViewsFactory.kt
+++ b/app/src/main/java/com/ivyclub/contact/service/ContactRemoteViewsFactory.kt
@@ -2,7 +2,6 @@ package com.ivyclub.contact.service
 
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService
 import com.ivyclub.contact.R
@@ -60,7 +59,7 @@ class ContactRemoteViewsFactory(
         val dateText = String.format(
             context.getString(R.string.format_date_day),
             planDate.getDayOfMonth(),
-            planDate.getDayOfWeek().korean
+            planDate.getDayOfWeek().translated.invoke()
         )
         with(listviewWidget) {
             setTextViewText(

--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
@@ -101,14 +101,14 @@ class PlanDetailsFragment :
 
             planDetails.observe(viewLifecycleOwner) {
                 with(binding) {
-                    if(it.photoIdList.isEmpty()) {
-                        vpPhoto.isVisible = false
-                        sdicIndicator.isVisible = false
-                    } else {
-                        vpPhoto.adapter = PhotoAdapter(it.photoIdList)
-                        vpPhoto.orientation = ViewPager2.ORIENTATION_HORIZONTAL
-                        sdicIndicator.setViewPager2(vpPhoto)
-                    }
+//                    if(it.photoIdList.isEmpty()) {
+//                        vpPhoto.isVisible = false
+//                        sdicIndicator.isVisible = false
+//                    } else {
+//                        vpPhoto.adapter = PhotoAdapter(it.photoIdList)
+//                        vpPhoto.orientation = ViewPager2.ORIENTATION_HORIZONTAL
+//                        sdicIndicator.setViewPager2(vpPhoto)
+//                    }
                 }
             }
         }

--- a/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListAdapter.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListAdapter.kt
@@ -1,6 +1,5 @@
 package com.ivyclub.contact.ui.plan_list
 
-import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -111,7 +110,7 @@ class PlanListAdapter(
                 tvPlanDate.text =
                     getDateFormatBy(
                         itemViewModel.planDayOfMonth.toString(),
-                        itemViewModel.planDayOfWeek
+                        itemViewModel.planDayOfWeek.translated.invoke()
                     )
                 tvPlanMonth.text = getMonthFormatBy(itemViewModel.planMonth)
                 viewModel = itemViewModel

--- a/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListItemViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/plan_list/PlanListItemViewModel.kt
@@ -14,6 +14,6 @@ data class PlanListItemViewModel(
     val planMonth = date.getExactMonth()
     val planYear = date.getExactYear()
     val planDayOfMonth = date.getDayOfMonth()
-    val planDayOfWeek = date.getDayOfWeek().korean
+    val planDayOfWeek = date.getDayOfWeek()
     val title: String = planData.title
 }

--- a/app/src/main/java/com/ivyclub/contact/util/EnumClasses.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/EnumClasses.kt
@@ -1,31 +1,31 @@
 package com.ivyclub.contact.util
 
-enum class DayOfWeek(val value: Int) : KoreanTranslatable {
+enum class DayOfWeek(val value: Int) : Translatable {
     SUN(1) {
-        override val korean = StringManager.getString("일")
+        override val translated = { StringManager.getString("일") }
     },
     MON(2) {
-        override val korean = StringManager.getString("월")
+        override val translated = { StringManager.getString("월") }
     },
     TUE(3) {
-        override val korean = StringManager.getString("화")
+        override val translated = { StringManager.getString("화") }
     },
     WED(4) {
-        override val korean = StringManager.getString("수")
+        override val translated = { StringManager.getString("수") }
     },
     THU(5) {
-        override val korean = StringManager.getString("목")
+        override val translated = { StringManager.getString("목") }
     },
     FRI(6) {
-        override val korean = StringManager.getString("금")
+        override val translated = { StringManager.getString("금") }
     },
     SAT(0) {
-        override val korean = StringManager.getString("토")
+        override val translated = { StringManager.getString("토") }
     }
 }
 
-interface KoreanTranslatable {
-    val korean: String
+interface Translatable {
+    val translated: () -> String
 }
 
 enum class FriendListViewType {


### PR DESCRIPTION
## Issue
- close #279 

## Overview (Required)
- 언어 변경 시 약속 리스트 아이템 요일 언어 변경 안되는 이슈 해결
    - 요일 Enum class에서 번역된 String을 val 형태에서 fun 형태로 받아오는 방식으로 수정 -> Configuration이 변경될 때마다 호출되어 바로 바뀐 언어형식으로 받아오도록 수정

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/48874574/147856507-76f59b25-34c4-41e7-a8ce-41dddb8d1669.png" width="300" /> | <img src="https://user-images.githubusercontent.com/48874574/147856522-dd0520a4-1e1b-4d41-971b-13e3ff95d29a.gif" width="300" />
