### PR TITLE
비밀번호 코드 리팩토링

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/password/PasswordFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/password/PasswordFragment.kt
@@ -132,14 +132,14 @@ class PasswordFragment :
     private fun observeTryCount() {
         viewModel.tryCount.observe(viewLifecycleOwner) { tryCount ->
             if (tryCount == 10) {
-                binding.tvPassword.text = "비밀번호를 10회 잘못 입력하셨습니다."
+                binding.tvPassword.text = getString(R.string.password_wrong_ten_times)
                 numberButtonList.forEach {
                     it.isClickable = false
                 }
                 viewModel.getTimerInfo()
                 viewModel.timer.observe(viewLifecycleOwner) {
                     binding.tvTryAfter.isVisible = true
-                    binding.tvTryAfter.text = "${it/60 + 1}분 후에 다시 시도해주세요."
+                    binding.tvTryAfter.text = String.format(getString(R.string.format_password_try_after), it/60 + 1)
                 }
             } else {
                 binding.tvPassword.text = getString(R.string.password_input_password)

--- a/app/src/main/java/com/ivyclub/contact/ui/password/PasswordFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/password/PasswordFragment.kt
@@ -49,8 +49,8 @@ class PasswordFragment :
         initPasswordViewType()
         initNumberClickListener()
         initCancelButtonClickListener()
-        initMoveFragmentObserver()
         initBackPressedListener()
+        observeMoveFragment()
         observeFocusedEditTextIndex()
         observeShowSnackBar()
         blockKeyboard()
@@ -203,7 +203,7 @@ class PasswordFragment :
         }
     }
 
-    private fun initMoveFragmentObserver() {
+    private fun observeMoveFragment() {
         viewModel.moveToSetPassword.observe(viewLifecycleOwner) {
             findNavController().navigate(
                 PasswordFragmentDirections.actionSetPasswordFragmentSelf(

--- a/app/src/main/java/com/ivyclub/contact/ui/password/PasswordViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/password/PasswordViewModel.kt
@@ -47,10 +47,14 @@ class PasswordViewModel @Inject constructor(private val repository: ContactRepos
     private val _fingerPrint = SingleLiveEvent<Unit>()
     val fingerPrint: LiveData<Unit> get() = _fingerPrint
 
-    val password1 = MutableLiveData("")
-    val password2 = MutableLiveData("")
-    val password3 = MutableLiveData("")
-    val password4 = MutableLiveData("")
+    private val _password1 = MutableLiveData("")
+    val password1: LiveData<String> get() = _password1
+    private val _password2 = MutableLiveData("")
+    val password2: LiveData<String> get() = _password2
+    private val _password3 = MutableLiveData("")
+    val password3: LiveData<String> get() = _password3
+    private val _password4 = MutableLiveData("")
+    val password4: LiveData<String> get() = _password4
 
     fun initPasswordViewType(type: PasswordViewType, password: String = "") {
         passwordViewType = type
@@ -73,16 +77,16 @@ class PasswordViewModel @Inject constructor(private val repository: ContactRepos
     private fun updatePasswordInput(number: String) {
         when (focusedEditTextIndex.value) {
             1 -> {
-                password1.value = number
+                _password1.value = number
             }
             2 -> {
-                password2.value = number
+                _password2.value = number
             }
             3 -> {
-                password3.value = number
+                _password3.value = number
             }
             4 -> {
-                password4.value = number
+                _password4.value = number
             }
         }
     }
@@ -151,10 +155,10 @@ class PasswordViewModel @Inject constructor(private val repository: ContactRepos
     }
 
     private fun reset() {
-        password1.value = ""
-        password2.value = ""
-        password3.value = ""
-        password4.value = ""
+        _password1.value = ""
+        _password2.value = ""
+        _password3.value = ""
+        _password4.value = ""
         _focusedEditTextIndex.value = 1
     }
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -157,4 +157,6 @@
     <string name="plan_noti_time_30m">30 min</string>
     <string name="plan_noti_time_1h">an hour</string>
     <string name="plan_noti_time_2h">2 hours</string>
+    <string name="password_wrong_ten_times">You entered incorrect password ten times</string>
+    <string name="format_password_try_after">Please try again after %d minutes</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,4 +171,6 @@
     <string name="plan_noti_time_30m">30분 전</string>
     <string name="plan_noti_time_1h">1시간 전</string>
     <string name="plan_noti_time_2h">2시간 전</string>
+    <string name="password_wrong_ten_times">비밀번호를 10회 잘못 입력하셨습니다.</string>
+    <string name="format_password_try_after">%d분 후에 다시 시도해주세요.</string>
 </resources>


### PR DESCRIPTION
## Issue
- close #276 

## Overview (Required)
- livedata observing 관련 메서드의 prefix를 observe-로 통일
- 이전에 하드코딩된 스트링 strings.xml로 추출 (중국어는 다음에 우진님께 여쭤보고 추가하겠습니다 ㅎㅎ)

원래 비밀번호 확인 코드와 비밀번호 설정 코드가 같이 있어서 그 둘을 분리하려고 했는데 결국은 분리하지 못했습니다 ㅜㅅㅠ
먼저 두 기능의 레이아웃이 똑같기 때문에 같은 레이아웃을 사용하고 비밀번호 확인과 비밀번호 설정에 공통적으로 필요한 기능들을 BasePasswordFragment와 BasePasswordViewModel을 abstract class로 만들어서 구현하려고 했는데 BasePasswordViewModel이 abstract로 되어있어서 인스턴스화가 안되어서 문제가 생겼습니다. 그래서 일반 클래스로 만들었는데 비밀번호 확인과 설정 코드가 서로 엉켜있어서 생각대로 잘 분리가 되지 않았습니다..
그래서 코드 중복이 발생하더라도 Base코드 없이 작성해보려고 했는데 이런 방법으로 하면 똑같은 레이아웃인데도 불구하고 각각 따로 레이아웃 파일을 만들어주어야 해서 코드 중복이 너무 많아져서 분리하지 않는 것보다 못할 것 같다는 판단이 서서 분리하지 않았습니다😢



