### PR TITLE
기기 재부팅 시 위젯 상태 유지

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/receivers/BootReceiver.kt
+++ b/app/src/main/java/com/ivyclub/contact/receivers/BootReceiver.kt
@@ -3,6 +3,7 @@ package com.ivyclub.contact.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.ivyclub.contact.service.WidgetProvider
 import com.ivyclub.contact.service.plan_reminder.PlanReminderMaker
 import com.ivyclub.contact.util.getNewTime
 import com.ivyclub.data.ContactRepository
@@ -31,6 +32,8 @@ class BootReceiver : BroadcastReceiver() {
                     reminderMaker.makePlanReminders(planData)
                 }
             }
+
+            context?.let { WidgetProvider.sendRefreshBroadcast(it) }
         }
     }
 }

--- a/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
@@ -58,6 +58,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     }
 
     private fun checkFromNotification() {
+        if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) return
+
         val fromNotification = intent.getBooleanExtra(NOTIFICATION, false)
         val planId = intent.getLongExtra(NOTI_PLAN_ID, -1L)
         if (fromNotification) {
@@ -73,11 +75,13 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                     }
                 }
             }
-            resetIntent(NOTIFICATION, NOTI_PLAN_ID)
+            intent.resetIntent(NOTIFICATION, NOTI_PLAN_ID)
         }
     }
 
     private fun checkFromWidget() {
+        if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) return
+
         val widgetPlanId = intent.getLongExtra(WIDGET_PLAN_ID, -1L)
         if (widgetPlanId != -1L && navController.currentDestination?.id == R.id.navigation_friend) {
             navController.navigate(
@@ -85,14 +89,12 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                     widgetPlanId
                 )
             )
-            resetIntent(WIDGET_PLAN_ID)
+            intent.resetIntent(WIDGET_PLAN_ID)
         }
     }
 
-    private fun resetIntent(vararg keys: String) {
-        val i = intent
-        keys.forEach { key -> i.removeExtra(key) }
-        intent = i
+    private fun Intent.resetIntent(vararg keys: String) {
+        keys.forEach { key -> removeExtra(key) }
     }
 
     private fun setObserver() {

--- a/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
@@ -70,10 +70,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
                                 planId
                             )
                         )
-                        resetIntent(NOTIFICATION, NOTI_PLAN_ID)
                     }
                 }
             }
+            resetIntent(NOTIFICATION, NOTI_PLAN_ID)
         }
     }
 

--- a/app/src/main/java/com/ivyclub/contact/util/BaseFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/BaseFragment.kt
@@ -5,9 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
+import androidx.core.view.children
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.RecyclerView
 
 abstract class BaseFragment<T : ViewDataBinding>(@LayoutRes val layoutRes: Int) : Fragment() {
 
@@ -25,7 +27,10 @@ abstract class BaseFragment<T : ViewDataBinding>(@LayoutRes val layoutRes: Int) 
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
+        (binding.root as ViewGroup).children
+            .filter { it is RecyclerView }
+            .forEach { (it as RecyclerView).adapter = null }
         _binding = null
+        super.onDestroyView()
     }
 }


### PR DESCRIPTION
## Issue
- close #303 

## Overview (Required)
- Fragment의 `onDestroy()` 시점에서 속 RecyclerView의 Adapter를 해제 -> Memory Leak 감소
- BootReceiver에서 Widget을 업데이트하는 로직을 추가하면서 기기 재부팅 시 위젯 업데이트 기능 활성화
- 위젯, 푸시 알림 검사시 최근 실행 앱 목록으로부터 실행되었는지 검사하는 로직 추가