### PR TITLE
계획 수정 시 기존 사진 불러오는 기능 추가

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanFragment.kt
@@ -199,9 +199,7 @@ class AddEditPlanFragment :
 
     private fun checkFrom() {
         if (args.planId != -1L) viewModel.getLastPlan(args.planId)
-        if (args.friendId != -1L) {
-            viewModel.addFriend(args.friendId)
-        }
+        if (args.friendId != -1L) viewModel.addFriend(args.friendId)
     }
 
     private fun getGroupSelectFragmentResult() {

--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
@@ -167,7 +167,7 @@ class AddEditPlanViewModel @Inject constructor(
             )
             else PlanData(participantIds, planDate, title, place, content, color)
         viewModelScope.launch {
-            saveImage(planImageUriList, repository.getNextPlanId() ?: 0L)
+            if(planImageUriList.isNotEmpty()) saveImage(planImageUriList, repository.getNextPlanId() ?: 0L)
             planId = repository.savePlanData(newPlan, lastParticipants)
             reminderMaker.makePlanReminders(
                 SimplePlanData(planId, title, planDate, participantIds)

--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
@@ -186,10 +186,7 @@ class AddEditPlanViewModel @Inject constructor(
         } else {
             planId.toString()
         }
-        if (planImageUriList.isNotEmpty()) ImageManager.savePlanBitmap(
-            planImageUriList,
-            currentPlanId
-        )
+        ImageManager.savePlanBitmap(planImageUriList, currentPlanId)
     }
 
     private fun makeSnackbar(strId: Int) {

--- a/app/src/main/java/com/ivyclub/contact/util/BindingAdapter.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/BindingAdapter.kt
@@ -3,6 +3,7 @@ package com.ivyclub.contact.util
 import android.widget.ImageView
 import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.signature.ObjectKey
 import com.ivyclub.contact.R
 import java.io.File
@@ -32,9 +33,10 @@ fun bindPlanImage(
     imageView: ImageView,
     imageString: String
 ) {
-    println(imageString)
     Glide.with(imageView)
         .load(imageString)
+        .diskCacheStrategy(DiskCacheStrategy.NONE) // 디스크 캐시 저장 끄기
+        .skipMemoryCache(true) // 메모리 캐시 저장 끄기
         .into(imageView)
     imageView.clipToOutline = true
 }

--- a/data/src/main/java/com/ivyclub/data/image/ImageManager.kt
+++ b/data/src/main/java/com/ivyclub/data/image/ImageManager.kt
@@ -20,16 +20,13 @@ object ImageManager {
         }
     }
 
+    // 기존 파일 삭제하고 새로운 bitmap list로 다시 파일들 생성
     fun savePlanBitmap(bitmapList: List<Bitmap>, planId: String) {
         runCatching {
             val folderPath = "${ImageType.PLAN_IMAGE.filePath}${planId}/"
             val file = File(folderPath)
-            if (file.exists()) {
-                file.deleteRecursively()
-                file.mkdirs()
-            } else {
-                file.mkdirs()
-            }
+            if (file.exists()) file.deleteRecursively()
+            file.mkdirs()
             bitmapList.forEachIndexed { index, bitmap ->
                 val tempFile = File(folderPath, "${index}.jpg").apply {
                     createNewFile()

--- a/data/src/main/java/com/ivyclub/data/image/ImageManager.kt
+++ b/data/src/main/java/com/ivyclub/data/image/ImageManager.kt
@@ -24,7 +24,12 @@ object ImageManager {
         runCatching {
             val folderPath = "${ImageType.PLAN_IMAGE.filePath}${planId}/"
             val file = File(folderPath)
-            if (!file.exists()) file.mkdirs()
+            if (file.exists()) {
+                file.deleteRecursively()
+                file.mkdirs()
+            } else {
+                file.mkdirs()
+            }
             bitmapList.forEachIndexed { index, bitmap ->
                 val tempFile = File(folderPath, "${index}.jpg").apply {
                     createNewFile()


### PR DESCRIPTION
## Issue
- close #305 

## Overview
- 계획 수정 시 기존 사진 불러와서 현재 사진 list에 반영
- 기존 사진에 추가 기능
- 기존 사진 삭제 기능
- Glide에 캐시가 적용되어 이전 사진이 보이는 것 캐시 비활성화

## Screenshot

https://user-images.githubusercontent.com/57510192/150549501-f9ccc31d-f29f-4771-8372-2ee40c74652f.mp4


