### PR TITLE
약속 수정 시 사진 변경 반영 안되는 이슈 해결

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
@@ -154,7 +154,7 @@ class AddEditPlanViewModel @Inject constructor(
             val lastPlanId = repository.getNextPlanId() ?: 0L
             if (planImageUriList.isNotEmpty()) ImageManager.savePlanBitmap(
                 planImageUriList,
-                (lastPlanId + 1).toString()
+                (if (planId == -1L) lastPlanId + 1 else planId).toString()
             )
             planId = repository.savePlanData(newPlan, lastParticipants)
             reminderMaker.makePlanReminders(


### PR DESCRIPTION
## Issue
- close #308 

## Overview (Required)
- 기존 약속 수정시 저장할 사진 경로 기존 약속 id로 변경
