### PR TITLE
[hotfix] app 모듈 plugin 순서 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
     id("kotlin-android")
     id("androidx.navigation.safeargs.kotlin")
     id("dagger.hilt.android.plugin")
-    id("com.google.firebase.crashlytics")
     id("com.google.gms.google-services")
     id("com.google.android.gms.oss-licenses-plugin")
+    id("com.google.firebase.crashlytics")
 }
 
 android {


### PR DESCRIPTION
## Overview
- actions 빌드 실패로 인해 app 모듈 plugin 순서 변경