### PR TITLE
약속 추가/수정 화면 초기에 기존 사진 개수 텍스트가 반영되지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanFragment.kt
@@ -50,11 +50,7 @@ class AddEditPlanFragment :
             activityViewModel.unlock()
             if (activityResult.resultCode == Activity.RESULT_OK && activityResult.data != null) {
                 if (activityResult.data?.clipData != null) { // 사용자가 이미지 여러 개 선택했을 때
-                    val currentImageCountText = binding.tvPhotoCount.text
-                    val originImageCount = currentImageCountText.substring(
-                        currentImageCountText.indexOf("(") + 1,
-                        currentImageCountText.indexOf("/")
-                    ).toInt() // 실제 값이 들어가는 부분이 1
+                    val originImageCount = viewModel.bitmapUriList.value?.size ?: 0
                     val selectedImageCount = activityResult.data?.clipData?.itemCount ?: 0
                     val imageUriList = mutableListOf<Uri>()
                     for (idx in 1..selectedImageCount) {
@@ -67,11 +63,6 @@ class AddEditPlanFragment :
                         )
                     }
                     viewModel.setPlanImageUri(imageUriList)
-                    binding.tvPhotoCount.text = String.format(
-                        requireContext().getString(R.string.add_edit_plan_fragment_image_count),
-                        selectedImageCount,
-                        MAX_PHOTO_COUNT
-                    )
                 } else { // 사용자가 이미지 하나 선택했을 때
                     val imageUri = activityResult.data?.data
                     viewModel.setPlanImageUri(listOf(imageUri ?: return@registerForActivityResult))

--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
@@ -53,8 +53,6 @@ class AddEditPlanViewModel @Inject constructor(
     val finishEvent: LiveData<Unit> = _finishEvent
     private val _bitmapUriList = MutableLiveData<List<Uri>>() // 계획 사진 uri 리스트
     val bitmapUriList: LiveData<List<Uri>> get() = _bitmapUriList
-    private val _imageCount = MutableLiveData(0)
-    val imageCount: LiveData<Int> get() = _imageCount
     val maxPhotoCount = MAX_PHOTO_COUNT
 
     fun getLastPlan(planId: Long) {
@@ -125,7 +123,6 @@ class AddEditPlanViewModel @Inject constructor(
     fun setPlanImageUri(newUriList: List<Uri>) {
         val originPlusNewUriList = (_bitmapUriList.value ?: emptyList()) + newUriList
         if (originPlusNewUriList.size > 5) return // 최대 사진 다섯 장
-        _imageCount.value = originPlusNewUriList.size
         _bitmapUriList.value = originPlusNewUriList
     }
 
@@ -208,7 +205,6 @@ class AddEditPlanViewModel @Inject constructor(
         if (position == -1) return
         val modifiedPhotoUriList = _bitmapUriList.value?.map { it }?.toMutableList()
         modifiedPhotoUriList?.removeAt(position)
-        _imageCount.postValue(modifiedPhotoUriList?.size)
         _bitmapUriList.postValue(modifiedPhotoUriList ?: emptyList())
     }
 

--- a/app/src/main/res/layout/fragment_add_edit_plan.xml
+++ b/app/src/main/res/layout/fragment_add_edit_plan.xml
@@ -204,12 +204,12 @@
                     android:id="@+id/btn_add_image"
                     android:layout_width="78dp"
                     android:layout_height="88dp"
+                    android:layout_marginStart="16dp"
                     android:backgroundTint="@color/light_gray"
                     android:textSize="12sp"
                     app:cornerRadius="2dp"
-                    app:layout_constraintBottom_toBottomOf="@id/rv_photo"
-                    app:layout_constraintStart_toStartOf="@id/act_plan_participants"
-                    app:layout_constraintTop_toTopOf="@id/rv_photo" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_add_image"
+                    app:layout_constraintStart_toStartOf="parent"/>
 
                 <ImageView
                     android:id="@+id/iv_plus_btn"
@@ -239,15 +239,15 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rv_photo"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
+                    android:layout_height="0dp"
                     android:paddingEnd="12dp"
                     android:clipToPadding="false"
                     android:orientation="horizontal"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/btn_add_image"
-                    app:layout_constraintTop_toBottomOf="@id/tv_add_image"
+                    app:layout_constraintTop_toTopOf="@id/btn_add_image"
+                    app:layout_constraintBottom_toBottomOf="@id/btn_add_image"
                     tools:listitem="@layout/item_image_at_add_page"
                     tools:ignore="RtlSymmetry" />
 

--- a/app/src/main/res/layout/fragment_add_edit_plan.xml
+++ b/app/src/main/res/layout/fragment_add_edit_plan.xml
@@ -204,6 +204,7 @@
                     android:id="@+id/btn_add_image"
                     android:layout_width="78dp"
                     android:layout_height="88dp"
+                    android:layout_marginTop="8dp"
                     android:layout_marginStart="16dp"
                     android:backgroundTint="@color/light_gray"
                     android:textSize="12sp"

--- a/app/src/main/res/layout/fragment_add_edit_plan.xml
+++ b/app/src/main/res/layout/fragment_add_edit_plan.xml
@@ -194,7 +194,7 @@
                     android:id="@+id/tv_photo_count"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@{String.format(@string/add_edit_plan_fragment_image_count, viewModel.imageCount, viewModel.maxPhotoCount)}"
+                    android:text="@{String.format(@string/add_edit_plan_fragment_image_count, viewModel.bitmapUriList.size, viewModel.maxPhotoCount)}"
                     app:layout_constraintBottom_toBottomOf="@id/tv_add_image"
                     app:layout_constraintEnd_toEndOf="@id/act_plan_participants"
                     app:layout_constraintTop_toTopOf="@id/tv_add_image"
@@ -239,15 +239,17 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rv_photo"
                     android:layout_width="0dp"
-                    android:layout_height="92dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:paddingEnd="12dp"
                     android:clipToPadding="false"
                     android:orientation="horizontal"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/btn_add_image"
                     app:layout_constraintTop_toBottomOf="@id/tv_add_image"
-                    tools:listitem="@layout/item_image_at_add_page" />
+                    tools:listitem="@layout/item_image_at_add_page"
+                    tools:ignore="RtlSymmetry" />
 
                 <TextView
                     android:id="@+id/tv_plan_what"

--- a/app/src/main/res/layout/item_image_at_add_page.xml
+++ b/app/src/main/res/layout/item_image_at_add_page.xml
@@ -18,6 +18,7 @@
             android:id="@+id/iv_image"
             android:layout_width="76dp"
             android:layout_height="76dp"
+            android:layout_margin="6dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -28,10 +29,10 @@
             android:id="@+id/circle_x_image_view"
             android:layout_width="16dp"
             android:layout_height="16dp"
+            android:padding="2dp"
+            android:alpha="0.7"
             android:backgroundTint="#808080"
-            app:layout_constraintBottom_toTopOf="@id/iv_image"
             app:layout_constraintEnd_toEndOf="@id/iv_image"
-            app:layout_constraintStart_toEndOf="@id/iv_image"
             app:layout_constraintTop_toTopOf="@id/iv_image" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Issue
- close #318 

## Overview (Required)
- DataBinding 수정으로 약속 추가/수정 화면 초기에 기존 사진 개수 텍스트가 반영되지 않는 문제 해결
- 사진 RecyclerView 및 item 레이아웃 수정

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/48874574/150907171-a2d38a52-3f17-4ac6-b085-89a8ed4f2cd6.jpg" width="300" /> | <img src="https://user-images.githubusercontent.com/48874574/150907212-c5cd0153-1baf-4a00-aa7e-8c40e14778f5.jpg" width="300" />
