### PR TITLE
약속 상세 정보 화면 초기에 사진 ViewPager indicator 반영되지 않는 문제 개선

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/plan_details/PlanDetailsFragment.kt
@@ -106,6 +106,7 @@ class PlanDetailsFragment :
                 with(binding) {
                     vpPhoto.adapter = PhotoAdapter(it, args.planId)
                     vpPhoto.orientation = ViewPager2.ORIENTATION_HORIZONTAL
+                    if (it.isNotEmpty()) vpPhoto.currentItem = 0
                     sdicIndicator.setViewPager2(vpPhoto)
                 }
             }


### PR DESCRIPTION
## Issue
- close #317 

## Overview (Required)
- 약속 상세 정보 화면 초기에 사진 ViewPager를 첫번째 페이지로 이동시키면서 문제 개선

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/48874574/150908310-dafe288b-9686-4fcd-8cce-9d9b2ab3e618.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/48874574/150908600-f930ed23-d4e5-42fd-90ef-0879552e3c57.gif" width="300" />

