### PR TITLE
약속 추가/수정 화면에서 모든 사진 삭제가 반영되지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/AddEditPlanViewModel.kt
@@ -167,7 +167,7 @@ class AddEditPlanViewModel @Inject constructor(
             )
             else PlanData(participantIds, planDate, title, place, content, color)
         viewModelScope.launch {
-            if(planImageUriList.isNotEmpty()) saveImage(planImageUriList, repository.getNextPlanId() ?: 0L)
+            saveImage(planImageUriList, repository.getNextPlanId() ?: 0L)
             planId = repository.savePlanData(newPlan, lastParticipants)
             reminderMaker.makePlanReminders(
                 SimplePlanData(planId, title, planDate, participantIds)


### PR DESCRIPTION
## Issue
- close #321 

## Overview (Required)
- 약속 수정 시 사진 리스트가 비어있는지에 대한 조건문을 제거하여 사진 삭제가 반영되도록 문제 개선

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/48874574/150910792-51f1b8de-607c-4f6b-9b33-4e920a7d9b24.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/48874574/150910836-7127079d-623f-4708-b799-cfe8cc02d8f5.gif" width="300" />
