### PR TITLE
약속 추가/수정 화면 사진 삭제 클릭 delay 해결

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/PhotoAdapter.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/add_edit_plan/PhotoAdapter.kt
@@ -9,6 +9,7 @@ import com.ivyclub.contact.R
 import com.ivyclub.contact.databinding.ItemImageAtAddPageBinding
 import com.ivyclub.contact.util.binding
 import com.ivyclub.contact.util.clicks
+import com.ivyclub.contact.util.throttleFist
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -41,7 +42,7 @@ class PhotoAdapter(
         RecyclerView.ViewHolder(binding.root) {
         init {
             binding.circleXImageView.clicks()
-                .debounce(700)
+                .throttleFist(700)
                 .onEach {
                     xButtonClickListener.invoke(adapterPosition)
                 }.launchIn(CoroutineScope(Dispatchers.IO))

--- a/app/src/main/java/com/ivyclub/contact/util/FlowExtension.kt
+++ b/app/src/main/java/com/ivyclub/contact/util/FlowExtension.kt
@@ -1,0 +1,22 @@
+package com.ivyclub.contact.util
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+
+fun <T> Flow<T>.throttleFist(windowDuration: Long): Flow<T> = flow {
+    var windowStartTime = System.currentTimeMillis()
+    var emitted = false
+    collect { value ->
+        val currentTime = System.currentTimeMillis()
+        val diff = currentTime - windowStartTime
+        if (diff >= windowDuration) {
+            windowStartTime += diff / windowDuration * windowDuration
+            emitted = false
+        }
+        if (!emitted) {
+            emit(value)
+            emitted = true
+        }
+    }
+}


### PR DESCRIPTION
## Issue
- close #323 

## Overview (Required)
- 사진 아이템 삭제 버튼 클릭 이벤트를 `debounce`가 아닌 `throttleFirst` 방식으로 변환하여 동작이 빠르게 되도록 개선
