### PR TITLE
[FIX] 오픈소스 라이선스 화면 갔다가 돌아올 때 다시 비밀번호 검사 안하도록 수정

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ivyclub/contact/ui/main/MainActivity.kt
@@ -23,6 +23,9 @@ import com.ivyclub.contact.ui.password.PasswordActivity
 import com.ivyclub.contact.util.BaseActivity
 import com.ivyclub.contact.util.hideKeyboard
 import dagger.hilt.android.AndroidEntryPoint
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
 
 @AndroidEntryPoint
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
@@ -54,7 +57,16 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
     override fun onStop() {
         super.onStop()
-        viewModel.lock()
+        val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val curComponentInfoInString = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            activityManager.appTasks[0].taskInfo.topActivity.toString()
+        } else {
+            activityManager.getRunningTasks(1)[0].topActivity.toString()
+        }
+
+        if ("OssLicensesMenuActivity" !in curComponentInfoInString) {
+            viewModel.lock()
+        }
     }
 
     private fun checkFromNotification() {


### PR DESCRIPTION
## Issue
- close #327 

## Overview (Required)
- 잠금기능 설정시 오픈소스 라이선스 화면으로 갔다가 나오면 다시 비밀번호 검사를 하는 버그 수정


