### PR TITLE
debug 모드에서는 Firebase crashlytics 수집 안되도록 하는 코드 추가

### DIFF
--- a/app/src/main/java/com/ivyclub/contact/MainApplication.kt
+++ b/app/src/main/java/com/ivyclub/contact/MainApplication.kt
@@ -3,6 +3,7 @@ package com.ivyclub.contact
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.ivyclub.contact.util.PixelRatio
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
@@ -20,6 +21,7 @@ class MainApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        FirebaseCrashlytics.getInstance().setCrashlyticsCollectionEnabled(!BuildConfig.DEBUG)
         initPixelRatio()
     }
 


### PR DESCRIPTION
## Issue
- close #336 

## Overview (Required)
- debug 모드에서는 Firebase crashlytics 수집 안되도록 하는 코드 추가

## Links
- https://stackoverflow.com/a/62915831/14155735
